### PR TITLE
Does not create new connection when a new one is created

### DIFF
--- a/Source/Helpers/MockTransportSession+connections.m
+++ b/Source/Helpers/MockTransportSession+connections.m
@@ -27,16 +27,6 @@
 
 @implementation MockTransportSession (ConnectionsHelper)
 
-- (MockConnection *)connectionByIdentifier:(NSString *)identifier
-{
-    NSFetchRequest *request = [MockConnection sortedFetchRequest];
-    request.predicate = [NSPredicate predicateWithFormat:@"to.identifier == %@", identifier];
-    
-    NSArray *connections = [self.managedObjectContext executeFetchRequestOrAssert:request];
-    RequireString(connections.count <= 1, "Too many connections with one identifier");
-    
-    return connections.count > 0 ? connections[0] : nil;
-}
 
 
 /// handles /connections
@@ -63,7 +53,7 @@
 - (ZMTransportResponse *)processPutConnection:(TestTransportSessionRequest *)sessionRequest
 {
     NSString *remoteID = sessionRequest.pathComponents[0];
-    MockConnection *connection = [self connectionByIdentifier:remoteID];
+    MockConnection *connection = [self connectionFromIdentifier:self.selfUser.identifier toIdentifier:remoteID];
     if (connection == nil) {
         return [ZMTransportResponse responseWithPayload:nil HTTPstatus:404 transportSessionError:nil];
     }
@@ -96,7 +86,8 @@
                     break;
                     
                 default:
-                connection.conversation.type = ZMTConversationTypeInvalid;
+                    connection.conversation.type = ZMTConversationTypeInvalid;
+                    break;	
             }
         }
     }
@@ -109,7 +100,7 @@
 - (ZMTransportResponse *)processGetSpecifiedConnection:(TestTransportSessionRequest *)sessionRequest
 {
     NSString *remoteID = sessionRequest.pathComponents[0];
-    MockConnection *connection = [self connectionByIdentifier:remoteID];
+    MockConnection *connection = [self connectionFromIdentifier:self.selfUser.identifier toIdentifier:remoteID];
     if (connection == nil) {
         return [ZMTransportResponse responseWithPayload:nil HTTPstatus:404 transportSessionError:nil];
     }

--- a/Source/Helpers/MockTransportSession+connections.m
+++ b/Source/Helpers/MockTransportSession+connections.m
@@ -53,7 +53,7 @@
 - (ZMTransportResponse *)processPutConnection:(TestTransportSessionRequest *)sessionRequest
 {
     NSString *remoteID = sessionRequest.pathComponents[0];
-    MockConnection *connection = [self connectionFromIdentifier:self.selfUser.identifier toIdentifier:remoteID];
+    MockConnection *connection = [self connectionFromUserIdentifier:self.selfUser.identifier toUserIdentifier:remoteID];
     if (connection == nil) {
         return [ZMTransportResponse responseWithPayload:nil HTTPstatus:404 transportSessionError:nil];
     }
@@ -100,7 +100,7 @@
 - (ZMTransportResponse *)processGetSpecifiedConnection:(TestTransportSessionRequest *)sessionRequest
 {
     NSString *remoteID = sessionRequest.pathComponents[0];
-    MockConnection *connection = [self connectionFromIdentifier:self.selfUser.identifier toIdentifier:remoteID];
+    MockConnection *connection = [self connectionFromUserIdentifier:self.selfUser.identifier toUserIdentifier:remoteID];
     if (connection == nil) {
         return [ZMTransportResponse responseWithPayload:nil HTTPstatus:404 transportSessionError:nil];
     }

--- a/Source/MockTransportSession+internal.h
+++ b/Source/MockTransportSession+internal.h
@@ -49,7 +49,8 @@
 - (void)addPushToken:(NSDictionary *)pushToken;
 - (ZMTransportResponse *)errorResponseWithCode:(NSInteger)code reason:(NSString *)reason;
 - (MockEvent *)eventIfNeededByUser:(MockUser *)byUser type:(ZMTUpdateEventType)type data:(id<ZMTransportData>)data;
-- (MockConnection *)connectionFromIdentifier:(NSString *)fromIdentifier toIdentifier:(NSString *)identifier;
+
+- (MockConnection *)connectionFromUserIdentifier:(NSString *)fromUserIdentifier toUserIdentifier:(NSString *)toUserIdentifier;
 
 @property (nonatomic, readonly) NSMutableSet *whitelistedEmails;
 @property (nonatomic, readonly) NSMutableSet *phoneNumbersWaitingForVerificationForRegistration;

--- a/Source/MockTransportSession+internal.h
+++ b/Source/MockTransportSession+internal.h
@@ -49,6 +49,7 @@
 - (void)addPushToken:(NSDictionary *)pushToken;
 - (ZMTransportResponse *)errorResponseWithCode:(NSInteger)code reason:(NSString *)reason;
 - (MockEvent *)eventIfNeededByUser:(MockUser *)byUser type:(ZMTUpdateEventType)type data:(id<ZMTransportData>)data;
+- (MockConnection *)connectionFromIdentifier:(NSString *)fromIdentifier toIdentifier:(NSString *)identifier;
 
 @property (nonatomic, readonly) NSMutableSet *whitelistedEmails;
 @property (nonatomic, readonly) NSMutableSet *phoneNumbersWaitingForVerificationForRegistration;

--- a/Source/MockTransportSession.m
+++ b/Source/MockTransportSession.m
@@ -322,6 +322,17 @@ static NSString * const HardcodedAccessToken = @"5hWQOipmcwJvw7BVwikKKN4glSue1Q7
     [request completeWithResponse:response];
 }
 
+- (MockConnection *)connectionFromIdentifier:(NSString *)fromIdentifier toIdentifier:(NSString *)toIdentifier;
+{
+    NSFetchRequest *request = [MockConnection sortedFetchRequest];
+    request.predicate = [NSPredicate predicateWithFormat:@"from.identifier == %@ AND to.identifier == %@", fromIdentifier, toIdentifier];
+    
+    NSArray *connections = [self.managedObjectContext executeFetchRequestOrAssert:request];
+    RequireString(connections.count <= 1, "Too many connections with one identifier");
+    
+    return [connections firstObject];
+}
+
 @end
 
 
@@ -1041,7 +1052,14 @@ static NSString * const HardcodedAccessToken = @"5hWQOipmcwJvw7BVwikKKN4glSue1Q7
             break;
         }
     }
-    MockConnection *connection = [MockConnection connectionInMOC:self.managedObjectContext from:fromUser to:toUser message:message];
+    
+    MockConnection *connection = [self connectionFromIdentifier:fromUser.identifier toIdentifier:toUser.identifier];
+    if (nil == connection) {
+        connection = [MockConnection connectionInMOC:self.managedObjectContext from:fromUser to:toUser message:message];
+    } else {
+        connection.message = message;
+        connection.conversation.type = ZMTConversationTypeConnection;
+    }
     connection.status = @"sent";
     MockConversation *conversation = existingConversation ?: [MockConversation conversationInMoc:self.managedObjectContext withCreator:fromUser otherUsers:@[] type:ZMTConversationTypeConnection];
     [conversation connectRequestByUser:fromUser toUser:toUser message:message];

--- a/Source/MockTransportSession.m
+++ b/Source/MockTransportSession.m
@@ -322,10 +322,10 @@ static NSString * const HardcodedAccessToken = @"5hWQOipmcwJvw7BVwikKKN4glSue1Q7
     [request completeWithResponse:response];
 }
 
-- (MockConnection *)connectionFromIdentifier:(NSString *)fromIdentifier toIdentifier:(NSString *)toIdentifier;
+- (MockConnection *)connectionFromUserIdentifier:(NSString *)fromUserIdentifier toUserIdentifier:(NSString *)toUserIdentifier;
 {
     NSFetchRequest *request = [MockConnection sortedFetchRequest];
-    request.predicate = [NSPredicate predicateWithFormat:@"from.identifier == %@ AND to.identifier == %@", fromIdentifier, toIdentifier];
+    request.predicate = [NSPredicate predicateWithFormat:@"from.identifier == %@ AND to.identifier == %@", fromUserIdentifier, toUserIdentifier];
     
     NSArray *connections = [self.managedObjectContext executeFetchRequestOrAssert:request];
     RequireString(connections.count <= 1, "Too many connections with one identifier");
@@ -1053,7 +1053,7 @@ static NSString * const HardcodedAccessToken = @"5hWQOipmcwJvw7BVwikKKN4glSue1Q7
         }
     }
     
-    MockConnection *connection = [self connectionFromIdentifier:fromUser.identifier toIdentifier:toUser.identifier];
+    MockConnection *connection = [self connectionFromUserIdentifier:fromUser.identifier toUserIdentifier:toUser.identifier];
     if (nil == connection) {
         connection = [MockConnection connectionInMOC:self.managedObjectContext from:fromUser to:toUser message:message];
     } else {

--- a/Tests/MockTransportSessionConnectionsTests.m
+++ b/Tests/MockTransportSessionConnectionsTests.m
@@ -217,13 +217,10 @@
     
     [self.sut performRemoteChanges:^(MockTransportSession<MockTransportSessionObjectCreation> *session) {
         NOT_USED(session);
-        XCTAssertEqual(user1.connectionsTo.count, 2u); // new connection should be created
-        MockConnection *firstConnection = [user1.connectionsTo firstObject];
-
-        XCTAssertNil(firstConnection.conversation);
-        MockConnection *newConnection = [user1.connectionsTo lastObject];
-        XCTAssertEqualObjects(newConnection.status, @"sent");
-        XCTAssertEqual(newConnection.conversation, conversation);
+        XCTAssertEqual(user1.connectionsTo.count, 1u); // new connection should not be created after resending
+        MockConnection *connection = [user1.connectionsTo lastObject];
+        XCTAssertEqualObjects(connection.status, @"sent");
+        XCTAssertEqualObjects(connection.conversation, conversation);
     }];
     WaitForAllGroupsToBeEmpty(0.5);
 }


### PR DESCRIPTION
**What's in this PR**
This PR fixes the behavior when creating a new connection. 
Previously, We would create a new connection every time  we would send a connection request, even though a connection between the same user exists. 
Now we would reuse the same connection and just change its state, instead of creating a new connection.