### PR TITLE
Add method to manually add a mock push event

### DIFF
--- a/Source/MockTransportSession.m
+++ b/Source/MockTransportSession.m
@@ -164,6 +164,11 @@ static NSString * const HardcodedAccessToken = @"5hWQOipmcwJvw7BVwikKKN4glSue1Q7
     
 }
 
+- (void)registerPushEvent:(MockPushEvent *)mockPushEvent
+{
+    [self.generatedPushEvents addObject:mockPushEvent];
+}
+
 - (void)addPushToken:(NSDictionary *)pushToken;
 {
     [(NSMutableArray *) self.pushTokens addObject:pushToken];
@@ -1268,6 +1273,7 @@ static NSString * const HardcodedAccessToken = @"5hWQOipmcwJvw7BVwikKKN4glSue1Q7
                                       @"type" : @"conversation.create",
                                       @"data" : conversation.transportData,
                                       @"conversation" : conversation.identifier,
+                                      @"time": NSDate.date.transportString
                                       };
             
             [pushEvents addObject:[MockPushEvent eventWithPayload:payload uuid:[NSUUID timeBasedUUID] fromUser:conversation.creator isTransient:NO]];
@@ -1438,7 +1444,6 @@ static NSString * const HardcodedAccessToken = @"5hWQOipmcwJvw7BVwikKKN4glSue1Q7
 - (void)firePushEvents:(NSArray<MockPushEvent *>*)events
 {
     events = [events sortedArrayUsingComparator:^NSComparisonResult(MockPushEvent *event1, MockPushEvent *event2) {
-        
         return [event1.timestamp compare:event2.timestamp];
     }];
     

--- a/Source/Model/MockConversation.m
+++ b/Source/Model/MockConversation.m
@@ -203,7 +203,7 @@ static NSString * const IdleString = @"idle";
     data[@"type"] = self.transportConversationType;
     data[@"last_event_time"] = self.lastEventTime ? [self.lastEventTime transportString] : [NSNull null];
     data[@"last_event"] = self.lastEvent ?: [NSNull null];
-    
+
     NSMutableDictionary *members = [NSMutableDictionary dictionary];
     data[@"members"] = members;
     members[@"self"] = [self selfInfoDictionary];

--- a/Source/Public/MockTransportSession.h
+++ b/Source/Public/MockTransportSession.h
@@ -29,6 +29,8 @@
 #import "MockPersonalInvitation.h"
 
 @class MockFlowManager;
+@class MockPushEvent;
+
 @protocol MockTransportSessionObjectCreation;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -83,6 +85,7 @@ typedef ZMTransportResponse * _Nullable (^ZMCustomResponseGeneratorBlock)(ZMTran
 
 - (void)completePreviouslySuspendendRequest:(ZMTransportRequest *)request;
 
+- (void)registerPushEvent:(MockPushEvent *)mockPushEvent;
 - (void)logoutSelfUser;
 
 @end


### PR DESCRIPTION
# What's in this PR?

This is needed to ensure the notification id is in the generated push events if the notification stream response has been mocked with a custom response generator.
If the notification ID is not registered the `/notifications` request will return a 404.