### PR TITLE
Add support for upload requests using a url instead of data

### DIFF
--- a/Source/Helpers/MockTransportSession+assets.m
+++ b/Source/Helpers/MockTransportSession+assets.m
@@ -310,7 +310,8 @@
 - (ZMTransportResponse *)processAssetV3Post:(TestTransportSessionRequest *)sessionRequest;
 {
     
-    NSArray *multipart = [sessionRequest.embeddedRequest multipartBodyItems];
+    NSArray *multipart = sessionRequest.multipartBodyItems;
+
     if (multipart.count == 2) {
         
         ZMMultipartBodyItem *jsonObject = [multipart firstObject];

--- a/Source/MockTransportSession+internal.h
+++ b/Source/MockTransportSession+internal.h
@@ -30,6 +30,7 @@
 @property (nonatomic, copy) NSDictionary *query;
 @property (nonatomic, readonly) ZMTransportRequestMethod method;
 @property (nonatomic, copy, readonly) id <ZMTransportData> payload;
+@property (nonatomic, readonly) NSArray<ZMMultipartBodyItem *> *multipartBodyItems;
 
 @property (nonatomic, copy) NSArray *pathComponents;
 @property (nonatomic, readonly, copy) NSString *binaryDataTypeAsMIME;

--- a/Source/MockTransportSession.m
+++ b/Source/MockTransportSession.m
@@ -1514,6 +1514,23 @@ static NSString * const HardcodedAccessToken = @"5hWQOipmcwJvw7BVwikKKN4glSue1Q7
     return [NSURL URLWithString:self.embeddedRequest.path];
 }
 
+- (NSArray<ZMMultipartBodyItem *> *)multipartBodyItems
+{
+    if (nil != self.embeddedRequest.multipartBodyItems) {
+        return self.embeddedRequest.multipartBodyItems;
+    }
+
+    NSURL *fileURL = self.embeddedRequest.fileUploadURL;
+    NSData *multipartData = [[NSData alloc] initWithContentsOfURL:fileURL];
+
+    if (nil == multipartData) {
+        return nil;
+    }
+
+    return [multipartData multipartDataItemsSeparatedWithBoundary:@"frontier"];
+
+}
+
 - (ZMTransportRequestMethod)method;
 {
     return self.embeddedRequest.method;


### PR DESCRIPTION
# What's in this PR?

* This is required by the changes made in https://github.com/wireapp/wire-ios-request-strategy/pull/9
* As we now upload assets using the background upload task the request data is not attached to the request as payload but instead the url of the data that is supposed to be uploaded is set. We now check if we have a `fileUploadURL` and try to get the multipart items from it if there are non attached to the request directly.