### PR TITLE
Remove location header and user rawResponse url instead

### DIFF
--- a/Tests/MockTransportSessionUsersTests.m
+++ b/Tests/MockTransportSessionUsersTests.m
@@ -560,7 +560,7 @@
     
     // then
     XCTAssertEqual(response.HTTPStatus, 200);
-    XCTAssertEqualObjects(response.headers[@"Location"], path);
+    XCTAssertEqualObjects(response.rawResponse.URL.path, path);
     [self checkThatTransportData:response.payload matchesUser:user isConnected:NO failureRecorder:NewFailureRecorder()];
 }
 
@@ -575,7 +575,7 @@
     
     // then
     XCTAssertEqual(response.HTTPStatus, 404);
-    XCTAssertEqualObjects(response.headers[@"Location"], path);
+    XCTAssertEqualObjects(response.rawResponse.URL.path, path);
 }
 
 @end


### PR DESCRIPTION
# What's in this PR?

* The BE does not set the Location header field as we assumed, we instead use the underlying `NSHTTPURLResponse` url to determine to which handle the request's response belonged to.