### PR TITLE
Add function to get user by ID

### DIFF
--- a/Source/MockTransportSession.m
+++ b/Source/MockTransportSession.m
@@ -868,6 +868,23 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
     [self.generatedPushEvents removeAllObjects];
 }
 
+- (MockUser *)userWithRemoteIdentifier:(NSString *)remoteIdentifier {
+    NSFetchRequest *userFetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"User"];
+    userFetchRequest.predicate = [NSPredicate predicateWithFormat:@"identifier == %@", remoteIdentifier];
+    
+    NSArray *results = [self.managedObjectContext executeFetchRequestOrAssert:userFetchRequest];
+    return results.firstObject;
+}
+
+- (MockUserClient *)clientForUser:(MockUser *)user remoteIdentifier:(NSString *)remoteIdentifier {
+    NSFetchRequest *userClientFetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"UserClient"];
+    userClientFetchRequest.predicate = [NSPredicate predicateWithFormat:@"identifier == %@ AND user == %@", remoteIdentifier, user];
+    
+    NSArray *results = [self.managedObjectContext executeFetchRequestOrAssert:userClientFetchRequest];
+    return results.firstObject;
+}
+
+
 @end
 
 

--- a/Source/Public/MockTransportSession.h
+++ b/Source/Public/MockTransportSession.h
@@ -148,6 +148,13 @@ typedef ZMTransportResponse * _Nullable (^ZMCustomResponseGeneratorBlock)(ZMTran
 - (void)deleteUserClientWithIdentifier:(NSString *)identifier forUser:(MockUser *)user;
 
 - (void)createAssetWithData:(NSData *)data identifier:(NSString *)identifier contentType:(NSString *)contentType forConversation:(NSString *)conversation;
+
+/// Returns the user (if any) with the given remote identifier
+- (nullable MockUser *)userWithRemoteIdentifier:(NSString *)remoteIdentifier;
+
+/// Returns the client (if any) for the given remote identifier
+- (nullable MockUserClient *)clientForUser:(MockUser *)user remoteIdentifier:(NSString *)remoteIdentifier;
+
 @end
 
 

--- a/Tests/MockTransportSessionObjectCreationTests.swift
+++ b/Tests/MockTransportSessionObjectCreationTests.swift
@@ -1,0 +1,99 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+
+class MockTransportSessionObjectCreationTests : MockTransportSessionTests {
+    
+    func testThatItDoesNotReturnNonExistingUserWithIdentifier() {
+        
+        // GIVEN
+        self.sut.performRemoteChanges { (session) in
+            session.insertUser(withName: "Foo")
+        }
+        
+        // WHEN
+        self.sut.performRemoteChanges { (session) in
+            let user = session.user(withRemoteIdentifier: "nonvalididentifier")
+            
+            // THEN
+            XCTAssertNil(user)
+        }
+    }
+    
+    func testThatItReturnsTheExistingUserWithIdentifier() {
+        
+        // GIVEN
+        var identifier: String!
+        self.sut.performRemoteChanges { (session) in
+            let user = session.insertUser(withName: "Foo")
+            identifier = user.identifier
+        }
+        
+        // WHEN
+        self.sut.performRemoteChanges { (session) in
+            let user = session.user(withRemoteIdentifier: identifier)
+            
+            // THEN
+            XCTAssertNotNil(user)
+            XCTAssertEqual(user?.identifier, identifier)
+        }
+    }
+    
+    func testThatItDoesNotReturnNonExistingClientWithIdentifier() {
+        
+        // GIVEN
+        var user: MockUser!
+        self.sut.performRemoteChanges { (session) in
+            user = session.insertUser(withName: "Foo")
+            session.registerClient(for: user, label: "iPhone 89", type: "permanent")
+        }
+        
+        // WHEN
+        self.sut.performRemoteChanges { (session) in
+            let client = session.client(for: user, remoteIdentifier: "invalid")
+            
+            // THEN
+            XCTAssertNil(client)
+        }
+    }
+    
+    func testThatItReturnsTheExistingClientWithIdentifier() {
+        
+        // GIVEN
+        var user: MockUser!
+        var identifier: String!
+        self.sut.performRemoteChanges { (session) in
+            user = session.insertUser(withName: "Foo")
+            let client = session.registerClient(for: user, label: "iPhone 89", type: "permanent")
+            identifier = client.identifier
+        }
+        
+        // WHEN
+        self.sut.performRemoteChanges { (session) in
+            let client = session.client(for: user, remoteIdentifier: identifier)
+            
+            // THEN
+            XCTAssertNotNil(client)
+            XCTAssertEqual(client?.identifier, identifier)
+            XCTAssertEqual(client?.user, user)
+        }
+    }
+    
+}

--- a/ZMCMockTransport.xcodeproj/project.pbxproj
+++ b/ZMCMockTransport.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		54CE5E741B753570007F3065 /* ocmock.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 54CE5E691B7534C4007F3065 /* ocmock.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		54CE5E751B753570007F3065 /* ZMCSystem.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 54CE5E6A1B7534C4007F3065 /* ZMCSystem.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		54CE5E771B753570007F3065 /* ZMUtilities.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 54CE5E6C1B7534C4007F3065 /* ZMUtilities.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		54FAE6821E3A025500E6DE42 /* MockTransportSessionObjectCreationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FAE6801E3A01F000E6DE42 /* MockTransportSessionObjectCreationTests.swift */; };
 		CE471AF31C19AC670040802B /* MockTransportSessionInvitationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CE471AF21C19AC670040802B /* MockTransportSessionInvitationTests.m */; };
 		CE4750291C19F73500848CCB /* MockPersonalInvitation.h in Headers */ = {isa = PBXBuildFile; fileRef = CE4750281C19F73500848CCB /* MockPersonalInvitation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE89FED31C19780D0093C3B6 /* MockPersonalInvitation.m in Sources */ = {isa = PBXBuildFile; fileRef = CE89FECF1C19780D0093C3B6 /* MockPersonalInvitation.m */; };
@@ -251,6 +252,7 @@
 		54CE5E6A1B7534C4007F3065 /* ZMCSystem.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZMCSystem.framework; path = Carthage/Build/iOS/ZMCSystem.framework; sourceTree = "<group>"; };
 		54CE5E6B1B7534C4007F3065 /* ZMTesting.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZMTesting.framework; path = Carthage/Build/iOS/ZMTesting.framework; sourceTree = "<group>"; };
 		54CE5E6C1B7534C4007F3065 /* ZMUtilities.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZMUtilities.framework; path = Carthage/Build/iOS/ZMUtilities.framework; sourceTree = "<group>"; };
+		54FAE6801E3A01F000E6DE42 /* MockTransportSessionObjectCreationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockTransportSessionObjectCreationTests.swift; sourceTree = "<group>"; };
 		CE471AF21C19AC670040802B /* MockTransportSessionInvitationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MockTransportSessionInvitationTests.m; sourceTree = "<group>"; };
 		CE4750281C19F73500848CCB /* MockPersonalInvitation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MockPersonalInvitation.h; sourceTree = "<group>"; };
 		CE89FECF1C19780D0093C3B6 /* MockPersonalInvitation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MockPersonalInvitation.m; sourceTree = "<group>"; };
@@ -438,6 +440,7 @@
 				CE471AF21C19AC670040802B /* MockTransportSessionInvitationTests.m */,
 				09E393F91BB0485300F3EA1B /* MockTransportSessionClientsTests.m */,
 				CE99C4A31D39183F0001D297 /* MockTransportSessionAssetsTests.m */,
+				54FAE6801E3A01F000E6DE42 /* MockTransportSessionObjectCreationTests.swift */,
 				54C902431B7532DD007162A8 /* Supporting Files */,
 				541797631CE1F86500C7646D /* ZMCMockTransportTests-ios-Bridging-Header.h */,
 			);
@@ -704,6 +707,7 @@
 				541797651CE1F86500C7646D /* MockTransportSessionCancelationTests.swift in Sources */,
 				54AE5AA41B78FA62002757E9 /* MockTransportSessionConnectionsTests.m in Sources */,
 				54AE5AA31B78FA62002757E9 /* MockTransportSessionCallingTests.m in Sources */,
+				54FAE6821E3A025500E6DE42 /* MockTransportSessionObjectCreationTests.swift in Sources */,
 				CE471AF31C19AC670040802B /* MockTransportSessionInvitationTests.m in Sources */,
 				54AE5AA81B78FA62002757E9 /* MockTransportSessionLoginTests.m in Sources */,
 				54AE5AA21B78FA62002757E9 /* MockTransportSessionAPNSTokenTests.m in Sources */,


### PR DESCRIPTION
This is needed when simulating receiving encrypted messages from remote clients: we want to let mocktransportsession handle all non-self client encryption contexts. So we will need to create a remote client for each local client (that is not self), and retrieve them later when we want to locally simulate and encrypted messages.