### PR TITLE
Performance: avoid generating too many prekeys

### DIFF
--- a/Source/Model/MockUserClient.swift
+++ b/Source/Model/MockUserClient.swift
@@ -149,7 +149,7 @@ extension MockUserClient {
         var generatedPrekeys : [[String: Any]]?
         var generatedLastPrekey : String?
         newClient.encryptionContext.perform { (session) in
-            generatedPrekeys = try? session.generatePrekeys(NSMakeRange(0, 100))
+            generatedPrekeys = try? session.generatePrekeys(NSMakeRange(0, 5))
             generatedLastPrekey = try? session.generateLastPrekey()
         }
         


### PR DESCRIPTION
In integration tests we create a set of user clients and for each of them generate 100 prekeys. This gets done on `setUp()` for each test which means it's repeated many times. 

Small benchmark - running `ConnectionTests`. Average of 3 runs on my laptop:
* With 100 prekeys: 25.6 s
* With 5 prekeys: 20.6 s

So the improvement is around 20%. Will see what are the real numbers when tests will be run on Jenkins box.
