### PR TITLE
Update lastUpdateDate when accepting a connection

### DIFF
--- a/Source/Model/MockConnection.m
+++ b/Source/Model/MockConnection.m
@@ -47,6 +47,7 @@
 - (void)accept
 {
     self.status = @"accepted";
+    self.lastUpdate = [NSDate date];
     RequireString(self.conversation != nil, "No conversation");
     NSArray *addedUsers = @[self.to];
     [self.conversation addUsersByUser:self.from addedUsers:addedUsers];


### PR DESCRIPTION
We rely on this date now when re-ordering a conversation after accepting it.