### PR TITLE
Added team permissions enforcing

### DIFF
--- a/Source/Public/MockTransportSession.h
+++ b/Source/Public/MockTransportSession.h
@@ -64,6 +64,8 @@ typedef ZMTransportResponse * _Nullable (^ZMCustomResponseGeneratorBlock)(ZMTran
 
 @property (nonatomic) BOOL doNotRespondToRequests; //to simulate offline
 
+@property (atomic) BOOL teamPermissionsEnforced; // Check permissions of selfUser for team calls, default = false
+
 @property (nonatomic) NSUInteger maxMembersForGroupCall;
 @property (nonatomic) NSUInteger maxCallParticipants;
 


### PR DESCRIPTION
To make it easier to do integration tests permissions enforcing is an opt-in - you need to set the `MockTransportSession.teamPermissionsEnforced` to true for it to work.
