### PR TITLE
Respecting permissions and memberships for push events

### DIFF
--- a/Source/Helpers/MockTransportSession+teams.swift
+++ b/Source/Helpers/MockTransportSession+teams.swift
@@ -115,10 +115,9 @@ extension MockTransportSession {
         if let permissionError = ensurePermission(.getMemberPermissions, in: team) {
             return permissionError
         }
-        let members = team.members ?? []
         
         let payload: [String : Any] = [
-            "members" : members.map { $0.payload }
+            "members" : team.members.map { $0.payload }
         ]
 
         return ZMTransportResponse(payload: payload as ZMTransportData, httpStatus: 200, transportSessionError: nil)

--- a/Source/Helpers/MockTransportSession+teams.swift
+++ b/Source/Helpers/MockTransportSession+teams.swift
@@ -124,10 +124,8 @@ extension MockTransportSession {
     }
     
     private func ensurePermission(_ permissions: Permissions, in team: MockTeam) -> ZMTransportResponse? {
-        guard teamPermissionsEnforced else { return nil }
-        guard let teamMembers = team.members,
-            let selfTeams = selfUser.memberships,
-            let member = selfTeams.union(teamMembers).first
+        guard let selfTeams = selfUser.memberships,
+            let member = selfTeams.union(team.members).first
             else { return .teamNotFound }
         
         guard member.permissions.contains(permissions) else {

--- a/Source/MockTransportSession.m
+++ b/Source/MockTransportSession.m
@@ -914,7 +914,12 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
 }
 
 - (MockConversation *)insertTeamConversationToTeam:(MockTeam *)team withUsers:(NSArray<MockUser *> *)users {
-    return [MockConversation insertConversationIntoContext:self.managedObjectContext forTeam:team with:users];
+    MockConversation *conversation = [MockConversation insertConversationIntoContext:self.managedObjectContext forTeam:team with:users];
+    NSAssert(self.selfUser.identifier, @"The self user needs to be set");
+    if ([conversation.activeUsers containsObject:self.selfUser]) {
+        conversation.selfIdentifier = self.selfUser.identifier;
+    }
+    return conversation;
 }
 
 - (void)deleteConversation:(nonnull MockConversation *)conversation
@@ -1001,7 +1006,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
             if (conversation.type == ZMTConversationTypeInvalid ||
                 conversation.selfIdentifier == nil ||
                 ![conversation.selfIdentifier isEqual:self.selfUser.identifier] ||
-                conversation.team != nil) // Team conversations are handled separately
+                (conversation.team != nil && [conversation.team containsUser:self.selfUser])) // Team conversations where you are a member are handled separately
             {
                 continue; // Conversation that's not visible to the user
             }

--- a/Source/MockTransportSession.swift
+++ b/Source/MockTransportSession.swift
@@ -20,21 +20,28 @@ import Foundation
 import CoreData
 
 public extension MockTransportSession {
+    private func selfUserPartOfTeam(_ team: MockTeam) -> Bool {
+        return team.contains(user: selfUser)
+    }
+    
     @objc(pushEventsForTeamsWithInserted:updated:deleted:shouldSendEventsToSelfUser:)
     public func pushEventsForTeams(inserted: Set<NSManagedObject>, updated: Set<NSManagedObject>, deleted: Set<NSManagedObject>, shouldSendEventsToSelfUser: Bool) -> [MockPushEvent] {
         guard shouldSendEventsToSelfUser else { return [] }
         
         let insertedEvents = inserted
             .flatMap { $0 as? MockTeam }
+            .filter(selfUserPartOfTeam)
             .map(MockTeamEvent.inserted)
             .map { MockPushEvent(with: $0.payload, uuid: UUID.create(), isTransient: false) }
         
         let updatedEvents =  updated
             .flatMap { $0 as? MockTeam }
+            .filter(selfUserPartOfTeam)
             .flatMap { self.pushEventForUpdatedTeam(team: $0, insertedObjects: inserted) }
         
         let deletedEvents = deleted
             .flatMap { $0 as? MockTeam }
+            .filter(selfUserPartOfTeam)
             .map(MockTeamEvent.deleted)
             .map { MockPushEvent(with: $0.payload, uuid: UUID.create(), isTransient: false) }
         

--- a/Source/MockTransportSession.swift
+++ b/Source/MockTransportSession.swift
@@ -24,23 +24,30 @@ public extension MockTransportSession {
         return team.contains(user: selfUser)
     }
     
+    private func ascendingCreationDate(first: MockTeam, second: MockTeam) -> Bool {
+        return first.createdAt < second.createdAt
+    }
+    
     @objc(pushEventsForTeamsWithInserted:updated:deleted:shouldSendEventsToSelfUser:)
     public func pushEventsForTeams(inserted: Set<NSManagedObject>, updated: Set<NSManagedObject>, deleted: Set<NSManagedObject>, shouldSendEventsToSelfUser: Bool) -> [MockPushEvent] {
         guard shouldSendEventsToSelfUser else { return [] }
         
         let insertedEvents = inserted
             .flatMap { $0 as? MockTeam }
+            .sorted(by: ascendingCreationDate)
             .filter(selfUserPartOfTeam)
             .map(MockTeamEvent.inserted)
             .map { MockPushEvent(with: $0.payload, uuid: UUID.create(), isTransient: false) }
         
         let updatedEvents =  updated
             .flatMap { $0 as? MockTeam }
+            .sorted(by: ascendingCreationDate)
             .filter(selfUserPartOfTeam)
             .flatMap { self.pushEventForUpdatedTeam(team: $0, insertedObjects: inserted) }
         
         let deletedEvents = deleted
             .flatMap { $0 as? MockTeam }
+            .sorted(by: ascendingCreationDate)
             .filter(selfUserPartOfTeam)
             .map(MockTeamEvent.deleted)
             .map { MockPushEvent(with: $0.payload, uuid: UUID.create(), isTransient: false) }

--- a/Source/Model/MockMember.swift
+++ b/Source/Model/MockMember.swift
@@ -48,6 +48,7 @@ extension MockMember {
     @objc(insertInContext:forUser:inTeam:)
     public static func insert(in context: NSManagedObjectContext, for user: MockUser, in team: MockTeam) -> MockMember {
         let member: MockMember = insert(in: context)
+        member.permissions = .member
         member.user = user
         member.team = team
         return member

--- a/Source/Model/MockTeam.swift
+++ b/Source/Model/MockTeam.swift
@@ -44,7 +44,7 @@ extension MockTeam {
     }
     
     public func contains(user: MockUser) -> Bool {
-        guard let userMemberships = user.memberships else { return false }
+        guard let userMemberships = user.memberships, !userMemberships.isEmpty else { return false }
         return !userMemberships.union(members).isEmpty
     }
     

--- a/Source/Model/MockTeam.swift
+++ b/Source/Model/MockTeam.swift
@@ -21,7 +21,7 @@ import CoreData
 
 @objc public final class MockTeam: NSManagedObject, EntityNamedProtocol {
     @NSManaged public var conversations: Set<MockConversation>?
-    @NSManaged public var members: Set<MockMember>?
+    @NSManaged public var members: Set<MockMember>
     @NSManaged public var creator: MockUser?
     @NSManaged public var name: String?
     @NSManaged public var pictureAssetKey: String?

--- a/Source/Model/MockTeam.swift
+++ b/Source/Model/MockTeam.swift
@@ -43,6 +43,11 @@ extension MockTeam {
         return NSPredicate(format: "%K == %@", #keyPath(MockTeam.identifier), identifier)
     }
     
+    public func contains(user: MockUser) -> Bool {
+        guard let userMemberships = user.memberships else { return false }
+        return !userMemberships.union(members).isEmpty
+    }
+    
     @objc
     public static func insert(in context: NSManagedObjectContext, name: String?, assetId: String?, assetKey: String?) -> MockTeam {
         let team: MockTeam = insert(in: context)

--- a/Source/Model/MockTeam.swift
+++ b/Source/Model/MockTeam.swift
@@ -43,6 +43,7 @@ extension MockTeam {
         return NSPredicate(format: "%K == %@", #keyPath(MockTeam.identifier), identifier)
     }
     
+    @objc(containsUser:)
     public func contains(user: MockUser) -> Bool {
         guard let userMemberships = user.memberships, !userMemberships.isEmpty else { return false }
         return !userMemberships.union(members).isEmpty

--- a/Source/Public/MockTransportSession.h
+++ b/Source/Public/MockTransportSession.h
@@ -64,8 +64,6 @@ typedef ZMTransportResponse * _Nullable (^ZMCustomResponseGeneratorBlock)(ZMTran
 
 @property (nonatomic) BOOL doNotRespondToRequests; //to simulate offline
 
-@property (atomic) BOOL teamPermissionsEnforced; // Check permissions of selfUser for team calls, default = false
-
 @property (nonatomic) NSUInteger maxMembersForGroupCall;
 @property (nonatomic) NSUInteger maxCallParticipants;
 

--- a/Tests/MockTransportSessionConversationsTests.m
+++ b/Tests/MockTransportSessionConversationsTests.m
@@ -1723,7 +1723,7 @@
 
 
 
-@implementation MockTransportSessionTests (ConversationArchiveAndMuted)
+@implementation MockTransportSessionConversationsTests (ConversationArchiveAndMuted)
 
 - (void)testThatItSetsTheArchivedEventOnTheConversationWhenAsked
 {
@@ -1858,7 +1858,7 @@
 @end
 
 
-@implementation  MockTransportSessionTests (IgnoringCall)
+@implementation MockTransportSessionConversationsTests (IgnoringCall)
 
 - (void)testThatCreatesAnEventForUserIgnoringCall
 {

--- a/Tests/MockTransportSessionRequestsTests.m
+++ b/Tests/MockTransportSessionRequestsTests.m
@@ -325,7 +325,7 @@
 
 
 
-@implementation MockTransportSessionTests (ListOfRequests)
+@implementation MockTransportSessionRequestsTests (ListOfRequests)
 
 - (void)sendRequestToMockTransportSession:(ZMTransportRequest *)request
 {

--- a/Tests/MockTransportSessionTeamEventsTests.swift
+++ b/Tests/MockTransportSessionTeamEventsTests.swift
@@ -63,11 +63,8 @@ class MockTransportSessionTeamEventsTests : MockTransportSessionTests {
         
         // When
         sut.performRemoteChanges { session in
-            team1 = session.insertTeam(withName: name1)
-        }
-        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        sut.performRemoteChanges { session in
-            team2 = session.insertTeam(withName: name2)
+            team1 = session.insertTeam(withName: name1, users: [self.sut.selfUser])
+            team2 = session.insertTeam(withName: name2, users: [self.sut.selfUser])
         }
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
@@ -85,11 +82,12 @@ class MockTransportSessionTeamEventsTests : MockTransportSessionTests {
         var teamIdentifier: String!
         
         sut.performRemoteChanges { session in
-            team = session.insertTeam(withName: "some")
+            let selfUser = session.insertSelfUser(withName: "Am I")
+            team = session.insertTeam(withName: "some", users: [selfUser])
             teamIdentifier = team.identifier
         }
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        createAndOpenPushChannel()
+        createAndOpenPushChannelAndCreateSelfUser(false)
 
         // When
         sut.performRemoteChanges { session in
@@ -109,10 +107,11 @@ class MockTransportSessionTeamEventsTests : MockTransportSessionTests {
         var team: MockTeam!
         
         sut.performRemoteChanges { session in
-            team = session.insertTeam(withName: "some")
+            let selfUser = session.insertSelfUser(withName: "Am I")
+            team = session.insertTeam(withName: "some", users: [selfUser])
         }
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        createAndOpenPushChannel()
+        createAndOpenPushChannelAndCreateSelfUser(false)
         
         // When
         let newName = "other"
@@ -142,12 +141,13 @@ class MockTransportSessionTeamEventsTests : MockTransportSessionTests {
         var team: MockTeam!
         
         sut.performRemoteChanges { session in
-            team = session.insertTeam(withName: "some")
+            let selfUser = session.insertSelfUser(withName: "Am I")
+            team = session.insertTeam(withName: "some", users: [selfUser])
             team.pictureAssetId = "123-082"
             team.pictureAssetKey = "541-992"
         }
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        createAndOpenPushChannel()
+        createAndOpenPushChannelAndCreateSelfUser(false)
         
         // When
         let newName = "other"
@@ -176,10 +176,11 @@ extension MockTransportSessionTeamEventsTests {
         var team: MockTeam!
         
         sut.performRemoteChanges { session in
-            team = session.insertTeam(withName: "some")
+            let selfUser = session.insertSelfUser(withName: "Am I")
+            team = session.insertTeam(withName: "some", users: [selfUser])
         }
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        createAndOpenPushChannel()
+        createAndOpenPushChannelAndCreateSelfUser(false)
         
         // When
         var newUser: MockUser!
@@ -205,12 +206,13 @@ extension MockTransportSessionTeamEventsTests {
         var user: MockUser!
         
         sut.performRemoteChanges { session in
-            team = session.insertTeam(withName: "some")
+            let selfUser = session.insertSelfUser(withName: "Am I")
+            team = session.insertTeam(withName: "some", users: [selfUser])
             user = session.insertUser(withName: "name")
             _ = session.insertMember(with: user, in: team)
         }
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        createAndOpenPushChannel()
+        createAndOpenPushChannelAndCreateSelfUser(false)
         
         // When
         sut.performRemoteChanges { session in
@@ -234,11 +236,12 @@ extension MockTransportSessionTeamEventsTests {
         var team2: MockTeam!
         
         sut.performRemoteChanges { session in
-            team1 = session.insertTeam(withName: "some")
-            team2 = session.insertTeam(withName: "other")
+            let selfUser = session.insertSelfUser(withName: "Am I")
+            team1 = session.insertTeam(withName: "some", users: [selfUser])
+            team2 = session.insertTeam(withName: "other", users: [selfUser])
         }
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        createAndOpenPushChannel()
+        createAndOpenPushChannelAndCreateSelfUser(false)
         
         // When
         var newUser: MockUser!
@@ -276,11 +279,12 @@ extension MockTransportSessionTeamEventsTests {
         var user: MockUser!
         
         sut.performRemoteChanges { session in
-            team = session.insertTeam(withName: "some")
+            let selfUser = session.insertSelfUser(withName: "Am I")
+            team = session.insertTeam(withName: "some", users: [selfUser])
             user = session.insertUser(withName: "some user")
         }
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        createAndOpenPushChannel()
+        createAndOpenPushChannelAndCreateSelfUser(false)
         
         // When
         var conversation: MockConversation!
@@ -308,14 +312,15 @@ extension MockTransportSessionTeamEventsTests {
         var conversationIdentifier: String!
 
         sut.performRemoteChanges { session in
-            team = session.insertTeam(withName: "some")
+            let selfUser = session.insertSelfUser(withName: "Am I")
+            team = session.insertTeam(withName: "some", users: [selfUser])
             user = session.insertUser(withName: "some user")
             conversation = session.insertTeamConversation(to: team, with: [user])
             conversationIdentifier = conversation.identifier
         }
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertEqual(conversation.team, team)
-        createAndOpenPushChannel()
+        createAndOpenPushChannelAndCreateSelfUser(false)
         
         // When
         sut.performRemoteChanges { session in

--- a/Tests/MockTransportSessionTeamEventsTests.swift
+++ b/Tests/MockTransportSessionTeamEventsTests.swift
@@ -359,4 +359,22 @@ extension MockTransportSessionTeamEventsTests {
         XCTAssertEqual(events.count, 0)
     }
     
+    func testThatItDoesSendConversationEventsInATeamConversationWhereYouAreGuest() {
+        // Given
+        createAndOpenPushChannel()
+        
+        // When
+        sut.performRemoteChanges { session in
+            let user1 = session.insertUser(withName: "one")
+            let team = session.insertTeam(withName: "some", users: [user1])
+            
+            let user2 = session.insertUser(withName: "some user")
+            _ = session.insertTeamConversation(to: team, with: [user1, user2, self.sut.selfUser])
+        }
+        
+        // Then
+        let events = pushChannelReceivedEvents as! [TestPushChannelEvent]
+        XCTAssertEqual(events.count, 1)
+
+    }
 }

--- a/Tests/MockTransportSessionTeamTests.swift
+++ b/Tests/MockTransportSessionTeamTests.swift
@@ -113,7 +113,8 @@ class MockTransportSessionTeamTests : MockTransportSessionTests {
         var creator: MockUser!
         
         sut.performRemoteChanges { session in
-            team = session.insertTeam(withName: "name")
+            let selfUser = session.insertSelfUser(withName: "Am I")
+            team = session.insertTeam(withName: "name", users: [selfUser])
             team.pictureAssetKey = "1234-abc"
             team.pictureAssetId = "123-1234-abc"
             creator = session.insertUser(withName: "creator")

--- a/Tests/MockTransportSessionTeamTests.swift
+++ b/Tests/MockTransportSessionTeamTests.swift
@@ -87,7 +87,8 @@ class MockTransportSessionTeamTests : MockTransportSessionTests {
         var creator: MockUser!
         
         sut.performRemoteChanges { session in
-            team = session.insertTeam(withName: "name")
+            let selfUser = session.insertSelfUser(withName: "Am I")
+            team = session.insertTeam(withName: "name", users: [selfUser])
             team.pictureAssetKey = "1234-abc"
             team.pictureAssetId = "123-1234-abc"
             creator = session.insertUser(withName: "creator")
@@ -249,28 +250,9 @@ class MockTransportSessionTeamTests : MockTransportSessionTests {
 }
 
 // MARK: - Team permissions
-extension MockTransportSessionTests {
-    func testThatItDoesNotReturnErrorForTeamsWhereUserIsNotAMemberWhenNotEnforced() {
-        // Given
-        var team: MockTeam!
-        
-        sut.performRemoteChanges { session in
-            _ = session.insertSelfUser(withName: "Am I")
-            team = session.insertTeam(withName: "name")
-        }
-        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
-        // When
-        let path = "/teams/\(team.identifier)"
-        let response = self.response(forPayload: nil, path: path, method: .methodGET)
-        
-        // Then
-        XCTAssertNotNil(response)
-        XCTAssertEqual(response?.httpStatus, 200)
-        XCTAssertNotNil(response?.payload)
-    }
+extension MockTransportSessionTeamTests {
     
-    func testThatItReturnsErrorForTeamsWhereUserIsNotAMemberWhenEnforced() {
+    func testThatItReturnsErrorForTeamsWhereUserIsNotAMember() {
         // Given
         var team: MockTeam!
         
@@ -281,7 +263,6 @@ extension MockTransportSessionTests {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // When
-        sut.teamPermissionsEnforced = true
         let path = "/teams/\(team.identifier)"
         let response = self.response(forPayload: nil, path: path, method: .methodGET)
         
@@ -292,7 +273,7 @@ extension MockTransportSessionTests {
         XCTAssertEqual(payload?["label"], "no-team")
     }
     
-    func testThatItReturnsErrorForTeamMembersWhereUserIsNotAMemberWhenEnforced() {
+    func testThatItReturnsErrorForTeamMembersWhereUserIsNotAMember() {
         // Given
         var team: MockTeam!
         
@@ -303,7 +284,6 @@ extension MockTransportSessionTests {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // When
-        sut.teamPermissionsEnforced = true
         let path = "/teams/\(team.identifier)/members"
         let response = self.response(forPayload: nil, path: path, method: .methodGET)
         
@@ -314,7 +294,7 @@ extension MockTransportSessionTests {
         XCTAssertEqual(payload?["label"], "no-team")
     }
 
-    func testThatItReturnsErrorForTeamMembersWhereUserDoesNotHavePermissionWhenEnforced() {
+    func testThatItReturnsErrorForTeamMembersWhereUserDoesNotHavePermission() {
         // Given
         var team: MockTeam!
         
@@ -327,7 +307,6 @@ extension MockTransportSessionTests {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // When
-        sut.teamPermissionsEnforced = true
         let path = "/teams/\(team.identifier)/members"
         let response = self.response(forPayload: nil, path: path, method: .methodGET)
         
@@ -413,18 +392,14 @@ extension MockTransportSessionTeamTests {
         var user1: MockUser!
         var user2: MockUser!
         var team: MockTeam!
-        var creator: MockUser!
         
         sut.performRemoteChanges { session in
-            team = session.insertTeam(withName: "name")
+            user1 = session.insertSelfUser(withName: "one")
+            user2 = session.insertUser(withName: "two")
+
+            team = session.insertTeam(withName: "name", users: [user1, user2])
             team.pictureAssetKey = "1234-abc"
             team.pictureAssetId = "123-1234-abc"
-            creator = session.insertUser(withName: "creator")
-            team.creator = creator
-            user1 = session.insertUser(withName: "one")
-            user2 = session.insertUser(withName: "two")
-            _ = session.insertMember(with: user1, in: team)
-            _ = session.insertMember(with: user2, in: team)
         }
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         

--- a/Tests/MockTransportSessionTests.m
+++ b/Tests/MockTransportSessionTests.m
@@ -140,18 +140,6 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransportTests";
     [super tearDown];
 }
 
-- (void)testThatACreatedUserHasValidatedEmail
-{
-    [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
-        // WHEN
-        MockUser *user = [session insertUserWithName:@"Mario"];
-        
-        // THEN
-        XCTAssertTrue(user.isEmailValidated);
-    }];
-    WaitForAllGroupsToBeEmpty(0.5);
-}
-
 @end
 
 

--- a/Tests/MockTransportSessionUsersTests.m
+++ b/Tests/MockTransportSessionUsersTests.m
@@ -26,6 +26,18 @@
 
 @implementation MockTransportSessionUsersTests
 
+- (void)testThatACreatedUserHasValidatedEmail
+{
+    [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
+        // WHEN
+        MockUser *user = [session insertUserWithName:@"Mario"];
+        
+        // THEN
+        XCTAssertTrue(user.isEmailValidated);
+    }];
+    WaitForAllGroupsToBeEmpty(0.5);
+}
+
 - (void)testCreatingAndRequestingSeveralUsers;
 {
     // GIVEN


### PR DESCRIPTION
## What's in this PR?

* Returns error when fetching team that you are not part of
* Permissions are respected when fetching team members
* Not sending update events for teams you are not part of
* Sending update events for guests in team conversation
* Cleaned up tests added to base classes (number of run test cases decreased from 502 to 252!).