### PR TITLE
API Update

### DIFF
--- a/Source/Helpers/MockTransportSession+teams.swift
+++ b/Source/Helpers/MockTransportSession+teams.swift
@@ -21,6 +21,7 @@ import WireDataModel
 
 extension ZMTransportResponse {
     static let teamNotFound = ZMTransportResponse(payload: ["label" : "no-team"] as ZMTransportData, httpStatus: 404, transportSessionError: nil)
+    static let notTeamMember = ZMTransportResponse(payload: ["label" : "no-team-member"] as ZMTransportData, httpStatus: 403, transportSessionError: nil)
     static let operationDenied = ZMTransportResponse(payload: ["label" : "operation-denied"] as ZMTransportData, httpStatus: 403, transportSessionError: nil)
 }
 
@@ -126,7 +127,7 @@ extension MockTransportSession {
     private func ensurePermission(_ permissions: Permissions, in team: MockTeam) -> ZMTransportResponse? {
         guard let selfTeams = selfUser.memberships,
             let member = selfTeams.union(team.members).first
-            else { return .teamNotFound }
+            else { return .notTeamMember }
         
         guard member.permissions.contains(permissions) else {
             return .operationDenied

--- a/Source/Model/MockConversation.m
+++ b/Source/Model/MockConversation.m
@@ -203,12 +203,7 @@ static NSString * const IdleString = @"idle";
     data[@"last_event_time"] = self.lastEventTime ? [self.lastEventTime transportString] : [NSNull null];
     data[@"last_event"] = self.lastEvent ?: [NSNull null];
     
-    if (self.team != nil) {
-        data[@"team"] = @{
-                          @"teamid" : self.team.identifier,
-                          @"managed" : @NO
-                          };
-    }
+    data[@"team"] = self.team.identifier ?: [NSNull null];
 
     NSMutableDictionary *members = [NSMutableDictionary dictionary];
     data[@"members"] = members;

--- a/Tests/MockTransportSessionAddressBookTests.m
+++ b/Tests/MockTransportSessionAddressBookTests.m
@@ -18,6 +18,7 @@
 
 
 #import "MockTransportSessionTests.h"
+@import WireMockTransport;
 
 @interface MockTransportSessionAddressBookTests : MockTransportSessionTests
 

--- a/Tests/MockTransportSessionCallingTests.m
+++ b/Tests/MockTransportSessionCallingTests.m
@@ -18,6 +18,7 @@
 
 
 #import "MockTransportSessionTests.h"
+@import WireMockTransport;
 
 @interface MockTransportSessionCallingTests : MockTransportSessionTests
 

--- a/Tests/MockTransportSessionConnectionsTests.m
+++ b/Tests/MockTransportSessionConnectionsTests.m
@@ -18,6 +18,7 @@
 
 
 #import "MockTransportSessionTests.h"
+@import WireMockTransport;
 
 @interface MockTransportSessionConnectionsTests : MockTransportSessionTests
 

--- a/Tests/MockTransportSessionConversationsTests.m
+++ b/Tests/MockTransportSessionConversationsTests.m
@@ -18,8 +18,7 @@
 
 
 #import "MockTransportSessionTests.h"
-#import <WireMockTransport/WireMockTransport-Swift.h>
-
+@import WireMockTransport;
 @import WireProtos;
 @import WireDataModel;
 

--- a/Tests/MockTransportSessionEmailPhoneVerificationTests.m
+++ b/Tests/MockTransportSessionEmailPhoneVerificationTests.m
@@ -18,7 +18,7 @@
 
 
 #import "MockTransportSessionTests.h"
-
+@import WireMockTransport;
 
 @interface MockTransportSessionEmailPhoneVerificationTests : MockTransportSessionTests
 

--- a/Tests/MockTransportSessionInvitationTests.m
+++ b/Tests/MockTransportSessionInvitationTests.m
@@ -18,6 +18,7 @@
 
 
 #import "MockTransportSessionTests.h"
+@import WireMockTransport;
 
 @interface MockTransportSessionInvitationTests : MockTransportSessionTests
 

--- a/Tests/MockTransportSessionLoginTests.m
+++ b/Tests/MockTransportSessionLoginTests.m
@@ -18,6 +18,7 @@
 
 
 #import "MockTransportSessionTests.h"
+@import WireMockTransport;
 
 @interface MockTransportSessionLoginTests : MockTransportSessionTests
 

--- a/Tests/MockTransportSessionRegistrationTests.m
+++ b/Tests/MockTransportSessionRegistrationTests.m
@@ -18,6 +18,7 @@
 
 
 #import "MockTransportSessionTests.h"
+@import WireMockTransport;
 
 @interface MockTransportSessionRegistrationTests : MockTransportSessionTests
 

--- a/Tests/MockTransportSessionSearchTests.m
+++ b/Tests/MockTransportSessionSearchTests.m
@@ -18,6 +18,7 @@
 
 
 #import "MockTransportSessionTests.h"
+@import WireMockTransport;
 
 @interface MockTransportSessionSearchTests : MockTransportSessionTests
 

--- a/Tests/MockTransportSessionTests.h
+++ b/Tests/MockTransportSessionTests.h
@@ -26,7 +26,6 @@
 #import "MockTransportSession+internal.h"
 #import "MockConnection.h"
 #import "MockFlowManager.h"
-#import <WireMockTransport/WireMockTransport-Swift.h>
 
 
 @interface TestPushChannelEvent : NSObject

--- a/Tests/MockTransportSessionTests.m
+++ b/Tests/MockTransportSessionTests.m
@@ -482,7 +482,7 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransportTests";
     [conversation.managedObjectContext performBlockAndWait:^{
         NSDictionary *dict = (id) data;
         XCTAssertTrue([dict isKindOfClass:[NSDictionary class]]);
-        NSArray *keys = @[@"creator", @"id", @"last_event", @"last_event_time", @"members", @"name", @"type"];
+        NSArray *keys = @[@"creator", @"id", @"last_event", @"last_event_time", @"members", @"name", @"type", @"team"];
         AssertDictionaryHasKeys(dict, keys);
         
         XCTAssertEqualObjects(dict[@"creator"], conversation.creator ? conversation.creator.identifier: [NSNull null]);

--- a/Tests/MockTransportSessionTests.m
+++ b/Tests/MockTransportSessionTests.m
@@ -26,6 +26,7 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransportTests";
 
 #import "MockTransportSessionTests.h"
 #import <libkern/OSAtomic.h>
+#import <WireMockTransport/WireMockTransport-Swift.h>
 
 @interface TestPushChannelEvent()
 


### PR DESCRIPTION
* Returning different error when user is not a member of the team
* Returning plain team id in conversation instead of object
* Fixed issues with debugger running in test suite