### PR TITLE
support account bound and unbound teams

### DIFF
--- a/Source/Helpers/MockTransportSession+teams.swift
+++ b/Source/Helpers/MockTransportSession+teams.swift
@@ -51,7 +51,11 @@ extension MockTransportSession {
     private func fetchTeam(with identifier: String?) -> ZMTransportResponse? {
         guard let identifier = identifier else { return nil }
         let predicate = MockTeam.predicateWithIdentifier(identifier: identifier)
-        guard let team: MockTeam = MockTeam.fetch(in: managedObjectContext, withPredicate: predicate) else { return .teamNotFound }
+        guard let team : MockTeam = MockTeam.fetch(in: managedObjectContext, withPredicate: predicate),
+              let selfMemberships = selfUser.memberships, selfMemberships.contains(where: {$0.team == team})
+        else {
+            return .teamNotFound
+        }
         if let permissionError = ensurePermission([], in: team) {
             return permissionError
         }
@@ -59,25 +63,10 @@ extension MockTransportSession {
     }
     
     private func fetchAllTeams(query: [String : Any]) -> ZMTransportResponse? {
-        var predicate: NSPredicate?
-        if let ids = query["ids"] as? String {
-            let teamIds = ids.components(separatedBy: ",")
-            predicate = NSPredicate(format: "%K in %@", #keyPath(MockTeam.identifier), teamIds)
-        }
-        
-        let sortDescriptors = [NSSortDescriptor(key: #keyPath(MockTeam.createdAt), ascending: true)]
-        let allTeams: [MockTeam] = MockTeam.fetchAll(in: managedObjectContext, withPredicate: predicate, sortBy: sortDescriptors)
-        
-        let startTeam = query["start"] as? String
-        var size: Int?
-        if let sizeString = query["size"] as? String {
-            size = Int(sizeString)
-        }
-        
-        let (teams, hasMore) = paginate(teams: allTeams, start: startTeam, size: size)
+        let teams = selfUser.memberships?.map{$0.team} ?? []
         let payload: [String : Any] = [
             "teams" : teams.map { $0.payload },
-            "has_more" : hasMore
+            "has_more" : false
         ]
         return ZMTransportResponse(payload: payload as ZMTransportData, httpStatus: 200, transportSessionError: nil)
     }

--- a/Source/MockTransportSession.m
+++ b/Source/MockTransportSession.m
@@ -878,14 +878,14 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
 
 #pragma mark - Teams
 
-- (MockTeam *)insertTeamWithName:(nullable NSString *)name
+- (MockTeam *)insertTeamWithName:(nullable NSString *)name isBound:(BOOL)isBound
 {
-    return [MockTeam insertIn:self.managedObjectContext name:name assetId:nil assetKey:nil];
+    return [MockTeam insertIn:self.managedObjectContext name:name assetId:nil assetKey:nil isBound:isBound];
 }
 
-- (MockTeam *)insertTeamWithName:(nullable NSString *)name users:(NSSet<MockUser*> *)users
+- (MockTeam *)insertTeamWithName:(nullable NSString *)name isBound:(BOOL)isBound users:(NSSet<MockUser*> *)users
 {
-    MockTeam *team = [MockTeam insertIn:self.managedObjectContext name:name assetId:nil assetKey:nil];
+    MockTeam *team = [MockTeam insertIn:self.managedObjectContext name:name assetId:nil assetKey:nil isBound:isBound];
     for (MockUser *user in users) {
         [self insertMemberWithUser:user inTeam:team];
     }
@@ -913,8 +913,8 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
     }
 }
 
-- (MockConversation *)insertTeamConversationToTeam:(MockTeam *)team withUsers:(NSArray<MockUser *> *)users {
-    MockConversation *conversation = [MockConversation insertConversationIntoContext:self.managedObjectContext forTeam:team with:users];
+- (MockConversation *)insertTeamConversationToTeam:(MockTeam *)team withUsers:(NSArray<MockUser *> *)users creator:(MockUser *)creator {
+    MockConversation *conversation = [MockConversation insertConversationIntoContext:self.managedObjectContext withCreator:creator forTeam:team users:users];
     NSAssert(self.selfUser.identifier, @"The self user needs to be set");
     if ([conversation.activeUsers containsObject:self.selfUser]) {
         conversation.selfIdentifier = self.selfUser.identifier;

--- a/Source/Model/MockConversation.swift
+++ b/Source/Model/MockConversation.swift
@@ -20,12 +20,13 @@ import Foundation
 import CoreData
 
 extension MockConversation {
-    @objc public static func insertConversationInto(context: NSManagedObjectContext, forTeam team: MockTeam, with users:[MockUser]) -> MockConversation {
+    @objc public static func insertConversationInto(context: NSManagedObjectContext, withCreator creator: MockUser, forTeam team: MockTeam, users:[MockUser]) -> MockConversation {
         let conversation = NSEntityDescription.insertNewObject(forEntityName: "Conversation", into: context) as! MockConversation
         conversation.type = .group
         conversation.team = team
         conversation.identifier = UUID.create().transportString()
         conversation.lastEventTime = Date()
+        conversation.creator = creator
         conversation.mutableOrderedSetValue(forKey: #keyPath(MockConversation.activeUsers)).addObjects(from: users)
         return conversation
     }

--- a/Source/Model/MockTeam.swift
+++ b/Source/Model/MockTeam.swift
@@ -28,6 +28,7 @@ import CoreData
     @NSManaged public var pictureAssetId: String
     @NSManaged public var identifier: String
     @NSManaged public var createdAt: Date
+    @NSManaged public var isBound: Bool
 
     public static var entityName = "Team"
     
@@ -50,21 +51,23 @@ extension MockTeam {
     }
     
     @objc
-    public static func insert(in context: NSManagedObjectContext, name: String?, assetId: String?, assetKey: String?) -> MockTeam {
+    public static func insert(in context: NSManagedObjectContext, name: String?, assetId: String?, assetKey: String?, isBound: Bool) -> MockTeam {
         let team: MockTeam = insert(in: context)
         team.name = name
         team.pictureAssetId = assetId ?? ""
         team.pictureAssetKey = assetKey
+        team.isBound = isBound
         return team
     }
     
-    var payloadValues: [String : String?] {
+    var payloadValues: [String : Any?] {
         return [
             "id": identifier,
             "name" : name,
             "icon_key" : pictureAssetKey,
             "icon" : pictureAssetId,
-            "creator" : creator?.identifier
+            "creator" : creator?.identifier,
+            "binding" : (isBound ? 1 : 0)
         ]
     }
     

--- a/Source/Model/MockTeamEvent.swift
+++ b/Source/Model/MockTeamEvent.swift
@@ -21,19 +21,14 @@ import Foundation
 @objc public class MockTeamEvent: NSObject {
     
     public enum Kind: String {
-        case create = "team.create"
         case delete = "team.delete"
         case update = "team.update"
     }
     
-    public let data: [String : String?]
+    public let data: [String : Any?]
     public let teamIdentifier: String
     public let kind: Kind
     public let timestamp = Date()
-    
-    public static func inserted(team: MockTeam) -> MockTeamEvent {
-        return MockTeamEvent(kind: .create, team: team, data: team.payloadValues)
-    }
     
     public static func updated(team: MockTeam, changedValues: [String: Any]) -> MockTeamEvent? {
         var data = [String : String?]()
@@ -64,7 +59,7 @@ import Foundation
         return MockTeamEvent(kind: .delete, team: team, data: [:])
     }
     
-    public init(kind: Kind, team: MockTeam, data: [String : String?]) {
+    public init(kind: Kind, team: MockTeam, data: [String : Any?]) {
         self.kind = kind
         self.teamIdentifier = team.identifier
         self.data = data

--- a/Source/Model/MockTeamMemberEvent.swift
+++ b/Source/Model/MockTeamMemberEvent.swift
@@ -31,12 +31,15 @@ import Foundation
     public let kind: Kind
     public let timestamp = Date()
 
-    public static func createIfNeeded(team: MockTeam, changedValues: [String: Any]) -> [MockTeamMemberEvent] {
+    public static func createIfNeeded(team: MockTeam, changedValues: [String: Any], selfUser: MockUser) -> [MockTeamMemberEvent] {
         let membersKey = #keyPath(MockTeam.members)
         let oldMembers = team.committedValues(forKeys: [membersKey])
         
         guard let currentMembers = changedValues[membersKey] as? Set<MockMember> else { return [] }
-        guard let previousMembers = oldMembers[membersKey] as? Set<MockMember> else { return [] }
+        let previousMembers = oldMembers[membersKey] as? Set<MockMember> ?? Set()
+        
+        guard    currentMembers.contains(where: { $0.user == selfUser })
+              || previousMembers.contains(where: { $0.user == selfUser }) else { return [] }
         
         let removedMembersEvents = previousMembers
             .subtracting(currentMembers)

--- a/Source/Model/MockTransportSession.xcdatamodeld/TestTransportSession.xcdatamodel/contents
+++ b/Source/Model/MockTransportSession.xcdatamodeld/TestTransportSession.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="12141" systemVersion="16E195" minimumToolsVersion="Xcode 4.3" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="12141" systemVersion="16F73" minimumToolsVersion="Xcode 4.3" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="">
     <entity name="Asset" representedClassName="MockAsset" syncable="YES">
         <attribute name="contentType" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="conversation" optional="YES" attributeType="String" syncable="YES"/>
@@ -83,6 +83,7 @@
     <entity name="Team" representedClassName=".MockTeam" syncable="YES">
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="identifier" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="isBound" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="pictureAssetId" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="pictureAssetKey" optional="YES" attributeType="String" syncable="YES"/>
@@ -141,7 +142,7 @@
         <element name="PersonalInvitation" positionX="0" positionY="0" width="128" height="135"/>
         <element name="Picture" positionX="0" positionY="0" width="128" height="120"/>
         <element name="PreKey" positionX="0" positionY="0" width="128" height="105"/>
-        <element name="Team" positionX="9" positionY="153" width="128" height="165"/>
+        <element name="Team" positionX="9" positionY="153" width="128" height="180"/>
         <element name="User" positionX="0" positionY="0" width="128" height="405"/>
         <element name="UserClient" positionX="0" positionY="0" width="128" height="255"/>
     </elements>

--- a/Source/Public/MockTransportSession.h
+++ b/Source/Public/MockTransportSession.h
@@ -156,12 +156,13 @@ typedef ZMTransportResponse * _Nullable (^ZMCustomResponseGeneratorBlock)(ZMTran
 /// Returns the client (if any) for the given remote identifier
 - (nullable MockUserClient *)clientForUser:(MockUser *)user remoteIdentifier:(NSString *)remoteIdentifier;
 
-- (MockTeam *)insertTeamWithName:(nullable NSString *)name;
-- (MockTeam *)insertTeamWithName:(nullable NSString *)name users:(NSSet<MockUser*> *)users;
+/// isBound means the team was created with version2 of teams and is bound to this user account
+- (MockTeam *)insertTeamWithName:(nullable NSString *)name isBound:(BOOL)isBound;
+- (MockTeam *)insertTeamWithName:(nullable NSString *)name isBound:(BOOL)isBound users:(NSSet<MockUser*> *)users;
 - (MockMember *)insertMemberWithUser:(MockUser *)user inTeam:(MockTeam *)team;
 - (void)removeMemberWithUser:(MockUser *)user fromTeam:(MockTeam *)team;
 - (void)deleteTeam:(nonnull MockTeam *)team;
-- (MockConversation *)insertTeamConversationToTeam:(MockTeam *)team withUsers:(NSArray<MockUser *> *)users;
+- (MockConversation *)insertTeamConversationToTeam:(MockTeam *)team withUsers:(NSArray<MockUser *> *)users creator:(MockUser *)creator;
 - (void)deleteConversation:(nonnull MockConversation *)conversation;
 
 @end


### PR DESCRIPTION
replaces https://github.com/wireapp/wire-ios-mocktransport/pull/49

We now support bound and unbound teams, meaning legacy teams which are not bound to an account and will return `"binding" : false` when fetched from the backend and teams which are bound to an account and will return `"binding": true`

We will also not receive update events for inserted teams anymore meaning that a team has to be created before the user is logged in.

