### PR TITLE
Set internal selfUser also when logging in

### DIFF
--- a/Source/Helpers/MockTransportSession+login.m
+++ b/Source/Helpers/MockTransportSession+login.m
@@ -77,6 +77,8 @@ static NSString * const HardcodedAccessToken = @"5hWQOipmcwJvw7BVwikKKN4glSue1Q7
         
         [self.cookieStorage setAuthenticationCookieData:[@"fake-cookie" dataUsingEncoding:NSUTF8StringEncoding]];
         
+        
+        self.selfUser = user;
         // also open push channel
         self.clientCompletedLogin = YES;
         [self simulatePushChannelOpened];


### PR DESCRIPTION
the internal `selfUser` was set on registration but not on login. If `selfUser` is not set calls to `/self` will just return an empty payload.