### PR TITLE
Delay opening the push channel until we say we want it to be open

### DIFF
--- a/Source/Helpers/MockTransportSession+login.m
+++ b/Source/Helpers/MockTransportSession+login.m
@@ -79,9 +79,7 @@ static NSString * const HardcodedAccessToken = @"5hWQOipmcwJvw7BVwikKKN4glSue1Q7
         
         
         self.selfUser = user;
-        // also open push channel
         self.clientCompletedLogin = YES;
-        [self simulatePushChannelOpened];
         
         NSDictionary *responsePayload = @{
                                           @"access_token" : HardcodedAccessToken,

--- a/Source/MockTransportSession.m
+++ b/Source/MockTransportSession.m
@@ -156,6 +156,10 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
 - (void)setKeepOpen:(BOOL)keepOpen
 {
     self.shouldKeepPushChannelOpen = keepOpen;
+    
+    if (self.shouldKeepPushChannelOpen && !self.shouldSendPushChannelEvents) {
+        [self simulatePushChannelOpened];
+    }
 }
 
 - (BOOL)keepOpen

--- a/Tests/MockTransportSessionPushChannelTests.m
+++ b/Tests/MockTransportSessionPushChannelTests.m
@@ -45,7 +45,6 @@
 {
     // GIVEN
     [self.sut.mockedTransportSession configurePushChannelWithConsumer:self groupQueue:self.fakeSyncContext];
-    [self.sut.mockedTransportSession.pushChannel setKeepOpen:YES];
     __block NSDictionary *payload;
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
         MockUser *selfUser = [session insertSelfUserWithName:@"Me Myself"];
@@ -54,9 +53,11 @@
         
         payload = @{@"email" : selfUser.email, @"password" : selfUser.password};
     }];
+    [self responseForPayload:payload path:@"/login" method:ZMMethodPOST]; // this will simulate the user logging in
     
     // WHEN
-    [self responseForPayload:payload path:@"/login" method:ZMMethodPOST]; // this will simulate the user logging in
+    [self.sut.mockedTransportSession.pushChannel setKeepOpen:YES];
+    WaitForAllGroupsToBeEmpty(0.5);
     
     // THEN
     XCTAssertEqual(self.pushChannelDidOpenCount, 1u);
@@ -507,7 +508,6 @@
 {
     // GIVEN
     [self.sut.mockedTransportSession configurePushChannelWithConsumer:self groupQueue:self.fakeSyncContext];
-    [self.sut.mockedTransportSession.pushChannel setKeepOpen:YES];
     
     __block MockUser *selfUser;
     NSString *email = @"doo@example.com";
@@ -527,6 +527,8 @@
                                                                @"email": email,
                                                                @"password": password
                                                                } path:path method:ZMMethodPOST];
+    [self.sut.mockedTransportSession.pushChannel setKeepOpen:YES];
+    
     WaitForAllGroupsToBeEmpty(0.5);
     
     // THEN

--- a/Tests/MockTransportSessionTests.m
+++ b/Tests/MockTransportSessionTests.m
@@ -177,9 +177,6 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransportTests";
     [self responseForPayload:payload path:@"/login" method:ZMMethodPOST]; // this will simulate the user logging in
     [self.sut.mockedTransportSession configurePushChannelWithConsumer:self groupQueue:self.fakeSyncContext];
     [self.sut.mockedTransportSession.pushChannel setKeepOpen:YES];
-    [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
-        [session simulatePushChannelOpened];
-    }];
     WaitForAllGroupsToBeEmpty(0.5);
 }
 


### PR DESCRIPTION
The previous behaviour wasn't not working after the registration re-factoring since we don't configure the push channel until after we have successfully logged in.