### PR TITLE
Moved tearing down to a separate method

### DIFF
--- a/Source/MockTransportSession.m
+++ b/Source/MockTransportSession.m
@@ -198,6 +198,12 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
 
 - (void)tearDown
 {
+    // Because we re-use the same MockTransportSession for both authenticated and unauthenticated sessions
+    // we don't want to do any tear down here. We should only tear it down after test is complete
+}
+
+- (void)cleanUp
+{
     self.managedObjectContext = nil;
     [self expireAllBlockedRequests];
     [self.generatedPushEvents removeAllObjects];

--- a/Source/Public/MockTransportSession.h
+++ b/Source/Public/MockTransportSession.h
@@ -84,6 +84,9 @@ typedef ZMTransportResponse * _Nullable (^ZMCustomResponseGeneratorBlock)(ZMTran
 - (void)registerPushEvent:(MockPushEvent *)mockPushEvent;
 - (void)logoutSelfUser;
 
+/// Called after test case is finished to release all resources
+- (void)cleanUp;
+
 @end
 
 


### PR DESCRIPTION
Because we reuse one instance of MockTransportSession for both authenticated and unauthenticated requests we need to make sure to only cleanup after the test is complete. Otherwise some requests could be dropped.