### PR TITLE
Remove legacy fields

### DIFF
--- a/Source/Model/MockConversation.swift
+++ b/Source/Model/MockConversation.swift
@@ -25,7 +25,6 @@ extension MockConversation {
         conversation.type = .group
         conversation.team = team
         conversation.identifier = UUID.create().transportString()
-        conversation.lastEventTime = Date()
         conversation.creator = creator
         conversation.mutableOrderedSetValue(forKey: #keyPath(MockConversation.activeUsers)).addObjects(from: users)
         return conversation

--- a/Source/Model/MockTransportSession.xcdatamodeld/TestTransportSession.xcdatamodel/contents
+++ b/Source/Model/MockTransportSession.xcdatamodeld/TestTransportSession.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="12141" systemVersion="16E195" minimumToolsVersion="Xcode 4.3" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="13241" systemVersion="16G29" minimumToolsVersion="Xcode 4.3" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="">
     <entity name="Asset" representedClassName="MockAsset" syncable="YES">
         <attribute name="contentType" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="conversation" optional="YES" attributeType="String" syncable="YES"/>
@@ -16,29 +16,18 @@
         <relationship name="to" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="connectionsTo" inverseEntity="User" syncable="YES"/>
     </entity>
     <entity name="Conversation" representedClassName="MockConversation" syncable="YES">
-        <attribute name="archived" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="clearedEventID" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="identifier" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="lastEvent" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="lastEventTime" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="lastRead" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="muted" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="mutedTime" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="otrArchived" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="otrArchivedRef" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="otrMuted" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="otrMutedRef" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="selfIdentifier" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="status" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="statusRef" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="statusTime" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="type" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <relationship name="activeUsers" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="User" inverseName="activeConversations" inverseEntity="User" syncable="YES"/>
         <relationship name="connection" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Connection" inverseName="conversation" inverseEntity="Connection" syncable="YES"/>
         <relationship name="creator" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="createdConversations" inverseEntity="User" syncable="YES"/>
         <relationship name="events" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Event" inverseName="conversation" inverseEntity="Event" syncable="YES"/>
-        <relationship name="inactiveUsers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="User" inverseName="inactiveConversations" inverseEntity="User" syncable="YES"/>
         <relationship name="team" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Team" inverseName="conversations" inverseEntity="Team" syncable="YES"/>
     </entity>
     <entity name="Event" representedClassName="MockEvent" syncable="YES">
@@ -105,7 +94,7 @@
         <relationship name="createdConversations" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Conversation" inverseName="creator" inverseEntity="Conversation" syncable="YES"/>
         <relationship name="createdEvents" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Event" inverseName="from" inverseEntity="Event" syncable="YES"/>
         <relationship name="createdTeams" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Team" inverseName="creator" inverseEntity="Team" syncable="YES"/>
-        <relationship name="inactiveConversations" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Conversation" inverseName="inactiveUsers" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="inactiveConversations" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Conversation" syncable="YES"/>
         <relationship name="invitations" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="PersonalInvitation" inverseName="inviter" inverseEntity="PersonalInvitation" syncable="YES"/>
         <relationship name="memberships" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Member" inverseName="user" inverseEntity="Member" syncable="YES"/>
         <relationship name="pictures" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Picture" inverseName="user" inverseEntity="Picture" syncable="YES"/>
@@ -129,7 +118,7 @@
     <elements>
         <element name="Asset" positionX="0" positionY="0" width="128" height="120"/>
         <element name="Connection" positionX="0" positionY="0" width="128" height="135"/>
-        <element name="Conversation" positionX="0" positionY="0" width="128" height="405"/>
+        <element name="Conversation" positionX="0" positionY="0" width="128" height="240"/>
         <element name="Event" positionX="0" positionY="0" width="128" height="150"/>
         <element name="Member" positionX="18" positionY="162" width="128" height="90"/>
         <element name="PersonalInvitation" positionX="0" positionY="0" width="128" height="135"/>

--- a/Source/Public/MockConversation.h
+++ b/Source/Public/MockConversation.h
@@ -36,30 +36,18 @@ typedef NS_ENUM(int16_t, ZMTConversationType) {
 
 @interface MockConversation : NSManagedObject
 
-@property (nonatomic, nullable) NSString *archived;
 @property (nonatomic, nullable) NSString *otrArchivedRef;
 @property (nonatomic, nullable) NSString *otrMutedRef;
 @property (nonatomic) BOOL otrArchived;
 @property (nonatomic) BOOL otrMuted;
 
-@property (nonatomic, nullable) NSString *clearedEventID;
 @property (nonatomic, nullable) MockUser *creator;
 @property (nonatomic, nonnull) NSString *identifier;
 @property (nonatomic, nonnull) NSString *selfIdentifier;
-@property (nonatomic, nullable) NSString *lastEvent;
-@property (nonatomic, nullable) NSDate *lastEventTime;
-@property (nonatomic, nullable) NSString *lastRead;
-@property (nonatomic) BOOL muted;
-@property (nonatomic, nullable) NSDate *mutedTime;
 @property (nonatomic, readonly, nullable) NSString *name;
-@property (nonatomic) int16_t status;
-@property (nonatomic, nullable) NSString *statusRef;
-@property (nonatomic, nullable) NSDate *statusTime;
 @property (nonatomic) ZMTConversationType type;
 /// participants that are not self
 @property (nonatomic, readonly, nonnull) NSOrderedSet *activeUsers;
-/// participants that are not self
-@property (nonatomic, readonly, nonnull) NSSet *inactiveUsers;
 
 @property (nonatomic, readonly, nonnull) NSOrderedSet *events;
 
@@ -97,9 +85,9 @@ typedef NS_ENUM(int16_t, ZMTConversationType) {
 - (nonnull MockEvent *)insertKnockFromUser:(nonnull MockUser *)fromUser nonce:(nonnull NSUUID *)nonce;
 - (nonnull MockEvent *)insertHotKnockFromUser:(nonnull MockUser *)fromUser nonce:(nonnull NSUUID *)nonce ref:(nonnull NSString *)eventID;
 - (nonnull MockEvent *)insertTypingEventFromUser:(nonnull MockUser *)fromUser isTyping:(BOOL)isTyping;
-- (nonnull MockEvent *)remotelyArchiveFromUser:(nonnull MockUser *)fromUser includeOTR:(BOOL)shouldIncludeOTR;;
-- (nonnull MockEvent *)remotelyClearHistoryFromUser:(nonnull MockUser *)fromUser includeOTR:(BOOL)shouldIncludeOTR;;
-- (nonnull MockEvent *)remotelyDeleteFromUser:(nonnull MockUser *)fromUser includeOTR:(BOOL)shouldIncludeOTR;;
+- (nonnull MockEvent *)remotelyArchiveFromUser:(nonnull MockUser *)fromUser referenceDate:(nonnull NSDate *)referenceDate;
+- (nonnull MockEvent *)remotelyClearHistoryFromUser:(nonnull MockUser *)fromUser referenceDate:(nonnull NSDate *)referenceDate;
+- (nonnull MockEvent *)remotelyDeleteFromUser:(nonnull MockUser *)fromUser referenceDate:(nonnull NSDate *)referenceDate;
 
 - (void)insertImageEventsFromUser:(nonnull MockUser *)fromUser;
 - (void)insertPreviewImageEventFromUser:(nonnull MockUser *)fromUser correlationID:(nonnull NSUUID *)correlationID none:(nonnull NSUUID *)nonce;

--- a/Tests/MockTransportSessionTests.m
+++ b/Tests/MockTransportSessionTests.m
@@ -481,7 +481,7 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransportTests";
     [conversation.managedObjectContext performBlockAndWait:^{
         NSDictionary *dict = (id) data;
         XCTAssertTrue([dict isKindOfClass:[NSDictionary class]]);
-        NSArray *keys = @[@"creator", @"id", @"last_event", @"last_event_time", @"members", @"name", @"type", @"team"];
+        NSArray *keys = @[@"creator", @"id", @"members", @"name", @"type", @"team"];
         AssertDictionaryHasKeys(dict, keys);
         
         XCTAssertEqualObjects(dict[@"creator"], conversation.creator ? conversation.creator.identifier: [NSNull null]);
@@ -493,52 +493,29 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransportTests";
         
         NSDictionary *selfMember = members[@"self"];
         XCTAssertTrue([selfMember isKindOfClass:[NSDictionary class]]);
-        keys = @[@"archived", @"id", @"muted", @"muted_time", @"status", @"last_read", @"cleared", @"otr_muted", @"otr_muted_ref", @"otr_archived", @"otr_archived_ref"];
+        keys = @[@"id", @"otr_muted", @"otr_muted_ref", @"otr_archived", @"otr_archived_ref"];
         AssertDictionaryHasKeys(selfMember, keys);
         
-        XCTAssertEqualObjects(selfMember[@"status"], @(conversation.status));
-        XCTAssertEqualObjects(selfMember[@"status_time"], [conversation.statusTime transportString]);
-        XCTAssertEqualObjects(selfMember[@"status_ref"], conversation.statusRef);
-        XCTAssertEqualObjects(selfMember[@"last_read"], [NSNull null]);
-        XCTAssertEqualObjects(selfMember[@"muted_time"], conversation.mutedTime ? [conversation.mutedTime transportString] : [NSNull null]);
-        XCTAssertEqualObjects(selfMember[@"muted"], @(conversation.muted));
         XCTAssertEqualObjects(selfMember[@"otr_muted"], @(conversation.otrMuted));
         XCTAssertEqualObjects(selfMember[@"otr_muted_ref"], conversation.otrMutedRef ?: [NSNull null]);
         XCTAssertEqualObjects(selfMember[@"otr_archived"], @(conversation.otrArchived));
         XCTAssertEqualObjects(selfMember[@"otr_archived_ref"], conversation.otrArchivedRef ?: [NSNull null]);
-        
-        XCTAssertEqualObjects(selfMember[@"archived"], [NSNull null]);
         XCTAssertEqualObjects(selfMember[@"id"], conversation.selfIdentifier);
-        XCTAssertEqualObjects(selfMember[@"cleared"], conversation.clearedEventID ? conversation.clearedEventID : [NSNull null]);
 
         NSMutableSet *activeOtherIDs = [NSMutableSet set];
         for (MockUser *user in conversation.activeUsers) {
             [activeOtherIDs addObject:user.identifier];
         }
         
-        NSMutableSet *inactiveOtherIDs = [NSMutableSet set];
-        for (MockUser *user in conversation.activeUsers) {
-            [inactiveOtherIDs addObject:user.identifier];
-        }
-        
         NSArray *others = members[@"others"];
         
         XCTAssertTrue([others isKindOfClass:[NSArray class]]);
-        XCTAssertEqual(conversation.activeUsers.count + conversation.inactiveUsers.count, 1 + others.count);
         for (NSDictionary *otherDict in others) {
             XCTAssertTrue([otherDict isKindOfClass:[NSDictionary class]]);
-            keys = @[@"id", @"status"];
+            keys = @[@"id"];
             AssertDictionaryHasKeys(otherDict, keys);
-            
-            NSNumber *status = otherDict[@"status"];
             NSString *uuidString = otherDict[@"id"];
-            if([status intValue] == 0) {
-                XCTAssertTrue([activeOtherIDs containsObject:uuidString], @"id %@ not found", uuidString);
-            }
-            else if([status intValue] == 1) {
-                XCTAssertTrue([inactiveOtherIDs containsObject:uuidString], @"id %@ not found", uuidString);
-            }
-            
+            XCTAssertTrue([activeOtherIDs containsObject:uuidString], @"id %@ not found", uuidString);
         }
         
         XCTAssertEqualObjects(dict[@"name"], conversation.name ?: [NSNull null]);
@@ -546,8 +523,6 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransportTests";
         XCTAssertNotNil(dict[@"type"]);
         ZMTConversationType t = (ZMTConversationType) ((NSNumber *)dict[@"type"]).intValue;
         XCTAssertEqual(t, conversation.type);
-        XCTAssertEqualObjects(dict[@"last_event_time"], [conversation.lastEventTime transportString]);
-        XCTAssertEqualObjects(dict[@"last_event"], conversation.lastEvent ?: [NSNull null]);
     }];
 }
 


### PR DESCRIPTION
remove `status`, `status_ref`,` status_time` from the self member object
remove `status` from the other member object (it is always 0)
remove `last_event` and `last_event_time` from the conversationMeta

in addition to that the following fields has also been removed:
`archived`, `clearedEventID`, `muted`, `mutedTime`, `lastRead`