### PR TITLE
Fix not updating the conversation type when accepting a connection request

### DIFF
--- a/Source/Model/MockConnection.m
+++ b/Source/Model/MockConnection.m
@@ -51,6 +51,7 @@
     RequireString(self.conversation != nil, "No conversation");
     NSArray *addedUsers = @[self.to];
     [self.conversation addUsersByUser:self.from addedUsers:addedUsers];
+    self.conversation.type = ZMTConversationTypeOneOnOne;
 }
 
 + (NSFetchRequest *)sortedFetchRequest;


### PR DESCRIPTION
After connection request has been accepted the `conversationType` should turn into a `oneToOne`.