### PR TITLE
Support for broadcast endpoint

### DIFF
--- a/Source/Helpers/MockTransportSession+Broadcast.h
+++ b/Source/Helpers/MockTransportSession+Broadcast.h
@@ -1,26 +1,25 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2017 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
-
+//
 
 #import "MockTransportSession+internal.h"
 
-@interface MockTransportSession (Conversations)
+@interface MockTransportSession (Broadcast)
 
-- (ZMTransportResponse *)processConversationsRequest:(ZMTransportRequest *)sessionRequest;
+- (ZMTransportResponse *)processBroadcastRequest:(ZMTransportRequest *)sessionRequest;
 
 @end

--- a/Source/Helpers/MockTransportSession+Broadcast.m
+++ b/Source/Helpers/MockTransportSession+Broadcast.m
@@ -1,0 +1,98 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+@import WireTransport;
+
+#import <WireMockTransport/WireMockTransport-Swift.h>
+#import "MockTransportSession+Broadcast.h"
+#import "MockTransportSession+OTR.h"
+
+@implementation MockTransportSession (Broadcast)
+
+- (ZMTransportResponse *)processBroadcastRequest:(ZMTransportRequest *)request
+{
+    if ([request matchesWithPath:@"/broadcast/otr/messages" method:ZMMethodPOST])
+    {
+        if (request.binaryData != nil) {
+            return [self processBroascastOTRMessageToConversationWithProtobuffData:request.binaryData
+                                                                             query:request.queryParameters];
+        }
+        else {
+            return [self processBroadcastOTRMessageWithPayload:[request.payload asDictionary]
+                                                         query:request.queryParameters];
+        }
+    }
+    
+    return [ZMTransportResponse responseWithPayload:nil HTTPStatus:404 transportSessionError:nil];
+}
+
+// POST /broadcast/otr/messages
+- (ZMTransportResponse *)processBroadcastOTRMessageWithPayload:(NSDictionary *)payload query:(NSDictionary *)query
+{
+    NSAssert(self.selfUser != nil, @"No self user in mock transport session");
+    
+    NSDictionary *recipients = payload[@"recipients"];
+    MockUserClient *senderClient = [self otrMessageSender:payload];
+    if (senderClient == nil) {
+        return [ZMTransportResponse responseWithPayload:nil HTTPStatus:404 transportSessionError:nil];
+    }
+    
+    NSString *onlyForUser = query[@"report_missing"];
+    NSDictionary *missedClients = [self missedClients:recipients sender:senderClient onlyForUserId:onlyForUser];
+    NSDictionary *redundantClients = [self redundantClients:recipients];
+    
+    NSDictionary *responsePayload = @{@"missing": missedClients, @"redundant": redundantClients, @"time": [NSDate date].transportString};
+    
+    NSInteger statusCode = 412;
+    if (missedClients.count == 0) {
+        statusCode = 201;
+    }
+    
+    return [ZMTransportResponse responseWithPayload:responsePayload HTTPStatus:statusCode transportSessionError:nil];
+}
+
+// POST /broadcast/otr/messages
+- (ZMTransportResponse *)processBroascastOTRMessageToConversationWithProtobuffData:(NSData *)binaryData query:(NSDictionary *)query
+{
+    NSAssert(self.selfUser != nil, @"No self user in mock transport session");
+    
+    ZMNewOtrMessage *otrMetaData = (ZMNewOtrMessage *)[[[ZMNewOtrMessage builder] mergeFromData:binaryData] build];
+    if (otrMetaData == nil) {
+        return [ZMTransportResponse responseWithPayload:nil HTTPStatus:404 transportSessionError:nil];
+    }
+    
+    MockUserClient *senderClient = [self otrMessageSenderFromClientId:otrMetaData.sender];
+    if (senderClient == nil) {
+        return [ZMTransportResponse responseWithPayload:nil HTTPStatus:404 transportSessionError:nil];
+    }
+    
+    NSString *onlyForUser = query[@"report_missing"];
+    NSDictionary *missedClients = [self missedClientsFromRecipients:otrMetaData.recipients sender:senderClient onlyForUserId:onlyForUser];
+    NSDictionary *redundantClients = [self redundantClientsFromRecipients:otrMetaData.recipients];
+    
+    NSDictionary *payload = @{@"missing": missedClients, @"redundant": redundantClients, @"time": [NSDate date].transportString};
+    
+    NSInteger statusCode = 412;
+    if (missedClients.count == 0) {
+        statusCode = 201;
+    }
+    
+    return [ZMTransportResponse responseWithPayload:payload HTTPStatus:statusCode transportSessionError:nil];
+}
+
+@end

--- a/Source/Helpers/MockTransportSession+OTR.h
+++ b/Source/Helpers/MockTransportSession+OTR.h
@@ -37,9 +37,18 @@
 /// @param onlyForUserId if not nil, only return missing recipients matching this user ID
 - (NSDictionary *)missedClients:(NSDictionary *)recipients conversation:(MockConversation *)conversation sender:(MockUserClient *)sender onlyForUserId:(NSString *)onlyForUserId;
 
+/// Returns a list of missing clients for broascasting that were not included in the list of intendend recipients
+/// @param recipients list of intender recipients
+/// @param onlyForUserId if not nil, only return missing recipients matching this user ID
+- (NSDictionary *)missedClients:(NSDictionary *)recipients sender:(MockUserClient *)sender onlyForUserId:(NSString *)onlyForUserId;
+
 /// Returns a list of redundant clients in the conversation that were included in the list of intendend recipients
 /// @param recipients list of intender recipients
 - (NSDictionary *)redundantClients:(NSDictionary *)recipients conversation:(MockConversation *)conversation;
+
+/// Returns a list of redundant clients for broascasting that were included in the list of intendend recipients
+/// @param recipients list of intender recipients
+- (NSDictionary *)redundantClients:(NSDictionary *)recipients;
 
 - (MockUserClient *)otrMessageSenderFromClientId:(ZMClientId *)sender;
 
@@ -48,9 +57,18 @@
 /// @param onlyForUserId if not nil, only return missing recipients matching this user ID
 - (NSDictionary *)missedClientsFromRecipients:(NSArray *)recipients conversation:(MockConversation *)conversation sender:(MockUserClient *)sender onlyForUserId:(NSString *)onlyForUserId;
 
+/// Returns a list of missing clients for broascasting that were not included in the list of intendend recipients
+/// @param recipients list of intender recipients
+/// @param onlyForUserId if not nil, only return missing recipients matching this user ID
+- (NSDictionary *)missedClientsFromRecipients:(NSArray *)recipients sender:(MockUserClient *)sender onlyForUserId:(NSString *)onlyForUserId;
+
 /// Returns a list of redundant clients in the conversation that were included in the list of intendend recipients
 /// @param recipients list of intender recipients
 - (NSDictionary *)redundantClientsFromRecipients:(NSArray *)recipients conversation:(MockConversation *)conversation;
+
+/// Returns a list of redundant clients for broascasting that were included in the list of intendend recipients
+/// @param recipients list of intender recipients
+- (NSDictionary *)redundantClientsFromRecipients:(NSArray *)recipients;
 
 
 - (void)insertOTRMessageEventsToConversation:(MockConversation *)conversation

--- a/Source/Helpers/MockTransportSession+OTR.m
+++ b/Source/Helpers/MockTransportSession+OTR.m
@@ -34,8 +34,18 @@
 
 - (NSDictionary *)missedClients:(NSDictionary *)recipients conversation:(MockConversation *)conversation sender:(MockUserClient *)sender onlyForUserId:(NSString *)onlyForUserId
 {
+    return [self missedClients:recipients users:conversation.activeUsers.set sender:sender onlyForUserId:onlyForUserId];
+}
+
+- (NSDictionary *)missedClients:(NSDictionary *)recipients sender:(MockUserClient *)sender onlyForUserId:(NSString *)onlyForUserId
+{
+    return [self missedClients:recipients users:self.selfUser.connectionsAndTeamMembers sender:sender onlyForUserId:onlyForUserId];
+}
+
+- (NSDictionary *)missedClients:(NSDictionary *)recipients users:(NSSet<MockUser *> *)users sender:(MockUserClient *)sender onlyForUserId:(NSString *)onlyForUserId
+{
     NSMutableDictionary *missedClients = [NSMutableDictionary new];
-    for (MockUser *user in conversation.activeUsers) {
+    for (MockUser *user in users) {
         if (onlyForUserId != nil && ![[NSUUID uuidWithTransportString:user.identifier] isEqual:[NSUUID uuidWithTransportString:onlyForUserId]]) {
             continue;
         }
@@ -58,10 +68,20 @@
 
 - (NSDictionary *)redundantClients:(NSDictionary *)recipients conversation:(MockConversation *)conversation
 {
+    return [self redundantClients:recipients users:conversation.activeUsers.set];
+}
+
+- (NSDictionary *)redundantClients:(NSDictionary *)recipients
+{
+    return [self redundantClients:recipients users:self.selfUser.connectionsAndTeamMembers];
+}
+
+- (NSDictionary *)redundantClients:(NSDictionary *)recipients users:(NSSet<MockUser *> *)users
+{
     NSMutableDictionary *redundantClients = [NSMutableDictionary new];
     for (NSString *userId in recipients) {
         NSDictionary *recipientPayload = recipients[userId];
-        MockUser *user = [conversation.activeUsers filteredOrderedSetUsingPredicate:[NSPredicate predicateWithFormat:@"identifier == %@", userId]].firstObject;
+        MockUser *user = [users filteredSetUsingPredicate:[NSPredicate predicateWithFormat:@"identifier == %@", userId]].anyObject;
         NSArray *recipientClients = [recipientPayload allKeys];
         NSSet *userClients = [user.clients mapWithBlock:^id(MockUserClient *client) {
             return client.identifier;
@@ -86,9 +106,19 @@
 
 - (NSDictionary *)missedClientsFromRecipients:(NSArray *)recipients conversation:(MockConversation *)conversation sender:(MockUserClient *)sender onlyForUserId:(NSString *)onlyForUserId
 {
+    return [self missedClientsFromRecipients:recipients users:conversation.activeUsers.set sender:sender onlyForUserId:onlyForUserId];
+}
+
+- (NSDictionary *)missedClientsFromRecipients:(NSArray *)recipients sender:(MockUserClient *)sender onlyForUserId:(NSString *)onlyForUserId
+{
+    return [self missedClientsFromRecipients:recipients users:self.selfUser.connectionsAndTeamMembers sender:sender onlyForUserId:onlyForUserId];
+}
+
+- (NSDictionary *)missedClientsFromRecipients:(NSArray *)recipients users:(NSSet<MockUser *> *)users sender:(MockUserClient *)sender onlyForUserId:(NSString *)onlyForUserId
+{
     NSMutableDictionary *missedClients = [NSMutableDictionary new];
 
-    for (MockUser *user in conversation.activeUsers) {
+    for (MockUser *user in users) {
         if (onlyForUserId != nil && ![[NSUUID uuidWithTransportString:user.identifier] isEqual:[NSUUID uuidWithTransportString:onlyForUserId]]) {
             continue;
         }
@@ -120,9 +150,19 @@
 
 - (NSDictionary *)redundantClientsFromRecipients:(NSArray *)recipients conversation:(MockConversation *)conversation
 {
+    return [self redundantClientsFromRecipients:recipients users:conversation.activeUsers.set];
+}
+
+- (NSDictionary *)redundantClientsFromRecipients:(NSArray *)recipients
+{
+    return [self redundantClientsFromRecipients:recipients users:self.selfUser.connectionsAndTeamMembers];
+}
+
+- (NSDictionary *)redundantClientsFromRecipients:(NSArray *)recipients users:(NSSet<MockUser *> *)users
+{
     NSMutableDictionary *redundantClients = [NSMutableDictionary new];
     
-    for (MockUser *user in conversation.activeUsers) {
+    for (MockUser *user in users) {
         ZMUserEntry *userEntry = [[recipients filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(ZMUserEntry  * _Nonnull evaluatedObject, NSDictionary<NSString *,id> * _Nullable __unused bindings) {
             NSUUID *uuid = [[NSUUID alloc] initWithUUIDBytes:evaluatedObject.user.uuid.bytes];
             NSUUID *userId = [NSUUID uuidWithTransportString:user.identifier];

--- a/Source/Helpers/MockTransportSession+conversations.m
+++ b/Source/Helpers/MockTransportSession+conversations.m
@@ -23,12 +23,10 @@
 @import WireProtos;
 @import WireDataModel;
 
-#import "MockTransportSession+internal.h"
-#import "MockTransportSession.h"
+#import "MockTransportSession+conversations.h"
 #import <WireMockTransport/WireMockTransport-Swift.h>
 #import "MockTransportSession+assets.h"
 #import "MockTransportSession+OTR.h"
-#import <WireMockTransport/WireMockTransport-Swift.h>
 
 
 

--- a/Source/MockTransportSession.m
+++ b/Source/MockTransportSession.m
@@ -427,7 +427,8 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
              @[@"/activate", @"processPhoneActivationRequest:"],
              @[@"/onboarding/v3", @"processOnboardingRequest:"],
              @[@"/invitations", @"processInvitationsRequest:"],
-             @[@"/teams", @"processTeamsRequest:"]
+             @[@"/teams", @"processTeamsRequest:"],
+             @[@"/broadcast", @"processBroadcastRequest:"]
              ];
 }
 

--- a/Source/Model/MockUser.swift
+++ b/Source/Model/MockUser.swift
@@ -73,16 +73,21 @@ extension MockUser {
     
     @objc public var connectionsAndTeamMembers : Set<MockUser> {
         
-        let connectedUsers = self.connectionsTo.flatMap { object -> MockUser? in
-            guard let connection = object as? MockConnection, MockConnection.status(from: connection.status) == .accepted else { return nil }
+        let acceptedUsers : (Any) -> MockUser? = { connection in
+            guard let connection = connection as? MockConnection, MockConnection.status(from: connection.status) == .accepted else { return nil }
             return connection.to == self ? connection.from : connection.to
         }
         
-        let teamMembers = self.createdTeams?.first?.members.map({ $0.user }) ?? []
+        let connectedToUsers : [MockUser] = self.connectionsTo.flatMap(acceptedUsers)
+        let connectedFromUsers : [MockUser] = self.connectionsFrom.flatMap(acceptedUsers)
+        
+        let teamMembers = self.memberships?.first?.team.members.map({ $0.user }) ?? []
         
         var users = Set<MockUser>()
-        users.formUnion(connectedUsers)
+        users.formUnion(connectedToUsers)
+        users.formUnion(connectedFromUsers)
         users.formUnion(teamMembers)
+        users.formUnion([self])
         
         return users
     }

--- a/Source/Model/MockUser.swift
+++ b/Source/Model/MockUser.swift
@@ -68,6 +68,28 @@ extension MockUser {
     }
 }
 
+// MARK: - Broadcasting
+extension MockUser {
+    
+    @objc public var connectionsAndTeamMembers : Set<MockUser> {
+        
+        let connectedUsers = self.connectionsTo.flatMap { object -> MockUser? in
+            guard let connection = object as? MockConnection, MockConnection.status(from: connection.status) == .accepted else { return nil }
+            return connection.to == self ? connection.from : connection.to
+        }
+        
+        let teamMembers = self.createdTeams?.first?.members.map({ $0.user }) ?? []
+        
+        var users = Set<MockUser>()
+        users.formUnion(connectedUsers)
+        users.formUnion(teamMembers)
+        
+        return users
+    }
+    
+}
+
+
 // MARK: - Images
 extension MockUser {
     @objc public var mediumImageIdentifier: String? {

--- a/Tests/MockTransportSessionBroadcastTests.swift
+++ b/Tests/MockTransportSessionBroadcastTests.swift
@@ -22,7 +22,15 @@ import WireDataModel
 
 class MockTransportSessionBroadcastTests: MockTransportSessionTests {
     
-    func testThatItReturnsMissingClientsWhenReceivingOTRMessage() {
+    func assertExpectedPayload(_ payload : [String : Any], in response:  ZMTransportResponse, file: StaticString = #file, line: UInt = #line) {
+        let missing = response.payload!.asDictionary()!["missing"] as! [String : Any]
+        let redundant = response.payload!.asDictionary()!["redundant"] as! [String : Any]
+        
+        XCTAssertTrue(NSDictionary(dictionary: missing).isEqual(to: payload["missing"]! as! [String : Any]), "missing clients: \n\(missing)\n doesn't match expected payload:\n \(payload)", file: file, line: line)
+        XCTAssertTrue(NSDictionary(dictionary: redundant).isEqual(to: payload["redundant"]! as! [String : Any]), "redundant clients: \n\(redundant)\n doesn't match expected payload:\n \(payload)", file: file, line: line)
+    }
+    
+    func testThatItReturnsMissingConnectedUsersWhenReceivingOTRMessage() {
         // given
         var selfUser : MockUser!
         var selfClient : MockUserClient!
@@ -31,6 +39,7 @@ class MockTransportSessionBroadcastTests: MockTransportSessionTests {
         var otherUser : MockUser!
         var otherUserClient : MockUserClient!
         var secondOtherUserClient : MockUserClient!
+        var otherUserRedundantClient : MockUserClient!
         
         sut.performRemoteChanges { session in
             selfUser = session.insertSelfUser(withName: "foo")
@@ -40,6 +49,10 @@ class MockTransportSessionBroadcastTests: MockTransportSessionTests {
             otherUser = session.insertUser(withName: "bar")
             otherUserClient = otherUser.clients.anyObject() as! MockUserClient
             secondOtherUserClient = session.registerClient(for: otherUser, label: "other2", type: "permanent")
+            otherUserRedundantClient = session.registerClient(for: otherUser, label: "other redundant", type: "permanent")
+            
+            let connection = session.insertConnection(withSelfUser: selfUser, to: otherUser)
+            connection.status = "accepted"
         }
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
@@ -47,21 +60,190 @@ class MockTransportSessionBroadcastTests: MockTransportSessionTests {
         let message = ZMGenericMessage.message(text: messageText, nonce: UUID.create().transportString())
         let base64Content = message.data().base64EncodedString()
         
-        let redundantClientId = NSString.createAlphanumerical()
         let payload : [String : Any] = [
             "sender": selfClient.identifier!,
             "recipients": [
                 otherUser.identifier :
                     [ otherUserClient.identifier!: base64Content,
-                      redundantClientId: base64Content] ]
+                      otherUserRedundantClient.identifier!: base64Content] ]
         ]
         
+        let protoPayload = selfClient.otrMessageBuilderWithRecipients(for: [otherUserClient, otherUserRedundantClient], plainText: message.data()).build().data()
+
+        sut.performRemoteChanges { session in
+            otherUserRedundantClient.user = nil
+        }
+        
         // when
-        let response = self.response(forPayload: payload as ZMTransportData, path: "/broadcast/otr/messages", method: .methodPOST)
+        let responseJSON = self.response(forPayload: payload as ZMTransportData, path: "/broadcast/otr/messages", method: .methodPOST)
+        let responsePROTO = self.response(forProtobufData: protoPayload, path: "/broadcast/otr/messages", method: .methodPOST)
         
         // then
-        XCTAssertNil(response)
-        XCTAssertEqual(response?.httpStatus, 412)
+        for response in [responseJSON, responsePROTO] {
+            XCTAssertNotNil(response)
+            
+            if let response = response {
+                XCTAssertEqual(response.httpStatus, 412)
+                
+                let expectedPayload = [
+                    "missing"  : [ selfUser.identifier  : [secondSelfClient.identifier!],
+                                   otherUser.identifier : [secondOtherUserClient.identifier!] ],
+                    "redundant" : [ otherUser.identifier : [otherUserRedundantClient.identifier!]]
+                ]
+                
+                assertExpectedPayload(expectedPayload, in: response)
+            }
+        }
+    }
+    
+    func testThatItReturnsMissingTeamMembersWhenReceivingOTRMessage() {
+        // given
+        var selfUser : MockUser!
+        var selfClient : MockUserClient!
+        
+        var otherUser : MockUser!
+        var otherUserClient : MockUserClient!
+        
+        sut.performRemoteChanges { session in
+            selfUser = session.insertSelfUser(withName: "Self User")
+            selfClient = session.registerClient(for: selfUser, label: "self user", type: "permanent")
+            
+            otherUser = session.insertUser(withName: "Team member1")
+            otherUserClient = otherUser.clients.anyObject() as! MockUserClient
+            
+            session.insertTeam(withName: "Team Foo", isBound: false, users: Set<MockUser>(arrayLiteral: selfUser, otherUser))
+        }
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        let message = ZMGenericMessage.message(text: "oaskdos", nonce: UUID.create().transportString())
+        let payload : [String : Any] = [
+            "sender": selfClient.identifier!,
+            "recipients": [:]
+        ]
+        
+        let protoPayload = selfClient.otrMessageBuilderWithRecipients(for: [], plainText: message.data()).build().data()
+        
+        // when
+        let responseJSON = self.response(forPayload: payload as ZMTransportData, path: "/broadcast/otr/messages", method: .methodPOST)
+        let responsePROTO = self.response(forProtobufData: protoPayload, path: "/broadcast/otr/messages", method: .methodPOST)
+        
+        // then
+        for response in [responseJSON, responsePROTO] {
+            XCTAssertNotNil(response)
+            
+            if let response = response {
+                XCTAssertEqual(response.httpStatus, 412)
+                
+                let expectedPayload = [
+                    "missing"  : [ otherUser.identifier : [otherUserClient.identifier!] ],
+                    "redundant" : [:]
+                ]
+                
+                assertExpectedPayload(expectedPayload, in: response)
+            }
+        }
+    }
+    
+    func testThatItAcceptsTeamMembersAsReceiversWhenReceivingOTRMessage() {
+        // given
+        var selfUser : MockUser!
+        var selfClient : MockUserClient!
+        
+        var otherUser : MockUser!
+        var otherUserClient : MockUserClient!
+        
+        sut.performRemoteChanges { session in
+            selfUser = session.insertSelfUser(withName: "Self User")
+            selfClient = session.registerClient(for: selfUser, label: "self user", type: "permanent")
+            
+            otherUser = session.insertUser(withName: "Team member1")
+            otherUserClient = otherUser.clients.anyObject() as! MockUserClient
+            
+            session.insertTeam(withName: "Team Foo", isBound: false, users: Set<MockUser>(arrayLiteral: selfUser, otherUser))
+        }
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        let messageText = "asdpasd"
+        let message = ZMGenericMessage.message(text: messageText, nonce: UUID.create().transportString())
+        let base64Content = message.data().base64EncodedString()
+        
+        let payload : [String : Any] = [
+            "sender": selfClient.identifier!,
+            "recipients": [ otherUser.identifier : [ otherUserClient.identifier!: base64Content] ]
+        ]
+        
+        let protoPayload = selfClient.otrMessageBuilderWithRecipients(for: [otherUserClient], plainText: message.data()).build().data()
+        
+        // when
+        let responseJSON = self.response(forPayload: payload as ZMTransportData, path: "/broadcast/otr/messages", method: .methodPOST)
+        let responsePROTO = self.response(forProtobufData: protoPayload, path: "/broadcast/otr/messages", method: .methodPOST)
+        
+        // then
+        for response in [responseJSON, responsePROTO] {
+            XCTAssertNotNil(response)
+            
+            if let response = response {
+                XCTAssertEqual(response.httpStatus, 201)
+                
+                let expectedPayload = [
+                    "missing"  : [:],
+                    "redundant" : [:]
+                ]
+                
+                assertExpectedPayload(expectedPayload, in: response)
+            }
+        }
+    }
+    
+    func testThatItAcceptsConnectedUsersAsReceiversWhenReceivingOTRMessage() {
+        // given
+        var selfUser : MockUser!
+        var selfClient : MockUserClient!
+        
+        var otherUser : MockUser!
+        var otherUserClient : MockUserClient!
+        
+        sut.performRemoteChanges { session in
+            selfUser = session.insertSelfUser(withName: "Self User")
+            selfClient = session.registerClient(for: selfUser, label: "self user", type: "permanent")
+            
+            otherUser = session.insertUser(withName: "Team member1")
+            otherUserClient = otherUser.clients.anyObject() as! MockUserClient
+            
+            let connection = session.insertConnection(withSelfUser: selfUser, to: otherUser)
+            connection.status = "accepted"
+        }
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        let messageText = "asdpasd"
+        let message = ZMGenericMessage.message(text: messageText, nonce: UUID.create().transportString())
+        let base64Content = message.data().base64EncodedString()
+        
+        let payload : [String : Any] = [
+            "sender": selfClient.identifier!,
+            "recipients": [ otherUser.identifier : [ otherUserClient.identifier!: base64Content] ]
+        ]
+        let protoPayload = selfClient.otrMessageBuilderWithRecipients(for: [otherUserClient], plainText: message.data()).build().data()
+        
+        // when
+        let responseJSON = self.response(forPayload: payload as ZMTransportData, path: "/broadcast/otr/messages", method: .methodPOST)
+        let responsePROTO = self.response(forProtobufData: protoPayload, path: "/broadcast/otr/messages", method: .methodPOST)
+        
+        // then
+        for response in [responseJSON, responsePROTO] {
+            XCTAssertNotNil(response)
+            
+            if let response = response {
+                XCTAssertEqual(response.httpStatus, 201)
+                
+                let expectedPayload = [
+                    "missing"  : [:],
+                    "redundant" : [:]
+                ]
+                
+                assertExpectedPayload(expectedPayload, in: response)
+            }
+        }
     }
     
 }

--- a/Tests/MockTransportSessionBroadcastTests.swift
+++ b/Tests/MockTransportSessionBroadcastTests.swift
@@ -1,0 +1,67 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+import WireDataModel
+@testable import WireMockTransport
+
+class MockTransportSessionBroadcastTests: MockTransportSessionTests {
+    
+    func testThatItReturnsMissingClientsWhenReceivingOTRMessage() {
+        // given
+        var selfUser : MockUser!
+        var selfClient : MockUserClient!
+        var secondSelfClient : MockUserClient!
+        
+        var otherUser : MockUser!
+        var otherUserClient : MockUserClient!
+        var secondOtherUserClient : MockUserClient!
+        
+        sut.performRemoteChanges { session in
+            selfUser = session.insertSelfUser(withName: "foo")
+            selfClient = session.registerClient(for: selfUser, label: "self user", type: "permanent")
+            secondSelfClient = session.registerClient(for: selfUser, label: "self2", type: "permanent")
+            
+            otherUser = session.insertUser(withName: "bar")
+            otherUserClient = otherUser.clients.anyObject() as! MockUserClient
+            secondOtherUserClient = session.registerClient(for: otherUser, label: "other2", type: "permanent")
+        }
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        let messageText = "asdpasd"
+        let message = ZMGenericMessage.message(text: messageText, nonce: UUID.create().transportString())
+        let base64Content = message.data().base64EncodedString()
+        
+        let redundantClientId = NSString.createAlphanumerical()
+        let payload : [String : Any] = [
+            "sender": selfClient.identifier!,
+            "recipients": [
+                otherUser.identifier :
+                    [ otherUserClient.identifier!: base64Content,
+                      redundantClientId: base64Content] ]
+        ]
+        
+        // when
+        let response = self.response(forPayload: payload as ZMTransportData, path: "/broadcast/otr/messages", method: .methodPOST)
+        
+        // then
+        XCTAssertNil(response)
+        XCTAssertEqual(response?.httpStatus, 412)
+    }
+    
+}

--- a/WireMockTransport.xcodeproj/project.pbxproj
+++ b/WireMockTransport.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		09E393F51BB0336A00F3EA1B /* MockPreKey.h in Headers */ = {isa = PBXBuildFile; fileRef = 09E393F31BB0336A00F3EA1B /* MockPreKey.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		09E393F81BB0339200F3EA1B /* MockPreKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E393F71BB0339200F3EA1B /* MockPreKey.m */; };
 		09E393FA1BB0485300F3EA1B /* MockTransportSessionClientsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E393F91BB0485300F3EA1B /* MockTransportSessionClientsTests.m */; };
+		163EB0CE1FD1A658005B8D8D /* MockTransportSession+Broadcast.h in Headers */ = {isa = PBXBuildFile; fileRef = 163EB0CC1FD1A658005B8D8D /* MockTransportSession+Broadcast.h */; };
+		163EB0CF1FD1A658005B8D8D /* MockTransportSession+Broadcast.m in Sources */ = {isa = PBXBuildFile; fileRef = 163EB0CD1FD1A658005B8D8D /* MockTransportSession+Broadcast.m */; };
+		163EB0D11FD1BDD4005B8D8D /* MockTransportSessionBroadcastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163EB0D01FD1BDD4005B8D8D /* MockTransportSessionBroadcastTests.swift */; };
 		5406F3D01E1D4A3900541E7F /* ZMTransportRequest+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5406F3CF1E1D4A3900541E7F /* ZMTransportRequest+Utils.swift */; };
 		541797651CE1F86500C7646D /* MockTransportSessionCancelationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541797641CE1F86500C7646D /* MockTransportSessionCancelationTests.swift */; };
 		541797671CE1FC0C00C7646D /* CustomResponseGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541797661CE1FC0C00C7646D /* CustomResponseGenerator.swift */; };
@@ -167,6 +170,9 @@
 		09E393F31BB0336A00F3EA1B /* MockPreKey.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MockPreKey.h; sourceTree = "<group>"; };
 		09E393F71BB0339200F3EA1B /* MockPreKey.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MockPreKey.m; sourceTree = "<group>"; };
 		09E393F91BB0485300F3EA1B /* MockTransportSessionClientsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MockTransportSessionClientsTests.m; sourceTree = "<group>"; };
+		163EB0CC1FD1A658005B8D8D /* MockTransportSession+Broadcast.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MockTransportSession+Broadcast.h"; sourceTree = "<group>"; };
+		163EB0CD1FD1A658005B8D8D /* MockTransportSession+Broadcast.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MockTransportSession+Broadcast.m"; sourceTree = "<group>"; };
+		163EB0D01FD1BDD4005B8D8D /* MockTransportSessionBroadcastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTransportSessionBroadcastTests.swift; sourceTree = "<group>"; };
 		5406F3CF1E1D4A3900541E7F /* ZMTransportRequest+Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMTransportRequest+Utils.swift"; sourceTree = "<group>"; };
 		541797631CE1F86500C7646D /* WireMockTransportTests-ios-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WireMockTransportTests-ios-Bridging-Header.h"; sourceTree = "<group>"; };
 		541797641CE1F86500C7646D /* MockTransportSessionCancelationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockTransportSessionCancelationTests.swift; sourceTree = "<group>"; };
@@ -348,6 +354,8 @@
 				09E393EC1BB012EA00F3EA1B /* MockTransportSession+Clients.m */,
 				09BCDB671BC7CFFC0020DCC7 /* MockTransportSession+OTR.h */,
 				09BCDB681BC7CFFC0020DCC7 /* MockTransportSession+OTR.m */,
+				163EB0CC1FD1A658005B8D8D /* MockTransportSession+Broadcast.h */,
+				163EB0CD1FD1A658005B8D8D /* MockTransportSession+Broadcast.m */,
 				CE89FED41C19865E0093C3B6 /* MockTransportSession+invitations.h */,
 				CE89FED51C19865E0093C3B6 /* MockTransportSession+invitations.m */,
 				5425EF031E1E3579006D7A01 /* MockTransportSession+notifications.h */,
@@ -472,6 +480,7 @@
 				54FAE6801E3A01F000E6DE42 /* MockTransportSessionObjectCreationTests.swift */,
 				F149F80D1ECC75C100B05E16 /* MockTransportSessionTeamTests.swift */,
 				F1782D901ED30F9900486BE3 /* MockTransportSessionTeamEventsTests.swift */,
+				163EB0D01FD1BDD4005B8D8D /* MockTransportSessionBroadcastTests.swift */,
 				F190E0931E8C0218003E81F8 /* MockUserTests.swift */,
 				54C902431B7532DD007162A8 /* Supporting Files */,
 				541797631CE1F86500C7646D /* WireMockTransportTests-ios-Bridging-Header.h */,
@@ -559,6 +568,7 @@
 			files = (
 				CE4750291C19F73500848CCB /* MockPersonalInvitation.h in Headers */,
 				CE89FED61C19865E0093C3B6 /* MockTransportSession+invitations.h in Headers */,
+				163EB0CE1FD1A658005B8D8D /* MockTransportSession+Broadcast.h in Headers */,
 				54AE5A891B78FA43002757E9 /* MockConnection.h in Headers */,
 				54AE5A791B78FA43002757E9 /* MockTransportSession+registration.h in Headers */,
 				54AE5A711B78FA43002757E9 /* MockTransportSession+assets.h in Headers */,
@@ -707,6 +717,7 @@
 				547AC6361E377B5A001458FD /* MockUserClient.swift in Sources */,
 				09E393F81BB0339200F3EA1B /* MockPreKey.m in Sources */,
 				54AE5A741B78FA43002757E9 /* MockTransportSession+connections.m in Sources */,
+				163EB0CF1FD1A658005B8D8D /* MockTransportSession+Broadcast.m in Sources */,
 				54AE5A821B78FA43002757E9 /* MockConversation.m in Sources */,
 				54AE5A7E1B78FA43002757E9 /* MockTransportSession.m in Sources */,
 				54AE5A721B78FA43002757E9 /* MockTransportSession+assets.m in Sources */,
@@ -734,6 +745,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				163EB0D11FD1BDD4005B8D8D /* MockTransportSessionBroadcastTests.swift in Sources */,
 				54AE5AA61B78FA62002757E9 /* MockTransportSessionEmailPhoneVerificationTests.m in Sources */,
 				09E393FA1BB0485300F3EA1B /* MockTransportSessionClientsTests.m in Sources */,
 				54AE5AA11B78FA62002757E9 /* MockTransportSessionAddressBookTests.m in Sources */,


### PR DESCRIPTION
## What's new

This PR adds support for the coming broadcast endpoint. This endpoint will allow a user to send a OTR message to all contacts and team members.

## What Changed

- Added `/broadcast/otr/messages`processing method
- Re-factored the OTR methods so they can be shared with the `conversations/<id>/otr/messages` endpoint

## NOTE
We will throw away the broadcasted message since it will be sent to the recipients' self-conversations, which isn't accessible by the self user.