### PR TITLE
Support for deleting the bot from the conversation

### DIFF
--- a/Source/Helpers/MockTransportSession+conversations.m
+++ b/Source/Helpers/MockTransportSession+conversations.m
@@ -98,6 +98,9 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransport";
     else if ([request matchesWithPath:@"/conversations/*/bots" method:ZMMethodPOST]) {
         return [self processServiceRequest:request];
     }
+    else if ([request matchesWithPath:@"/conversations/*/bots/*" method:ZMMethodDELETE]) {
+        return [self processDeleteBotRequest:request];
+    }
 
     return [ZMTransportResponse responseWithPayload:nil HTTPStatus:404 transportSessionError:nil];
 

--- a/Source/MockTransportSession.m
+++ b/Source/MockTransportSession.m
@@ -429,7 +429,8 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
              @[@"/invitations", @"processInvitationsRequest:"],
              @[@"/teams", @"processTeamsRequest:"],
              @[@"/broadcast", @"processBroadcastRequest:"],
-             @[@"/services", @"processServicesSearchRequest:"]
+             @[@"/services", @"processServicesSearchRequest:"],
+             @[@"/providers", @"processServicesProvidersRequest:"]
              ];
 }
 

--- a/Source/Model/MockService.swift
+++ b/Source/Model/MockService.swift
@@ -26,8 +26,16 @@ import Foundation
     @NSManaged public var handle: String?
     @NSManaged public var accentID: Int
     @NSManaged public var provider: String
-    
+    @NSManaged public var summary: String?
+    @NSManaged public var serviceDescription: String?
+    @NSManaged public var tag: String?
+
     @NSManaged public var assets: Set<MockAsset>?
+
+    @NSManaged public var providerURL: String?
+    @NSManaged public var providerName: String?
+    @NSManaged public var providerEmail: String?
+    @NSManaged public var providerDescription: String?
     
     override public func awakeFromInsert() {
         if accentID == 0 {
@@ -52,6 +60,8 @@ import Foundation
             "handle" : handle,
             "accent_id" : accentID,
             "provider" : provider,
+            "summary" : summary ?? "",
+            "tag" : tag ?? "",
             "assets" : (self.assets ?? Set()).map {
                 return ["type": "image",
                         "size": "preview",

--- a/Source/Model/MockTransportSession.xcdatamodeld/TestTransportSession.xcdatamodel/contents
+++ b/Source/Model/MockTransportSession.xcdatamodeld/TestTransportSession.xcdatamodel/contents
@@ -72,6 +72,13 @@
         <attribute name="identifier" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="provider" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="providerDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="providerEmail" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="providerName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="providerURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="serviceDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="summary" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="tag" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="assets" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Asset" inverseName="userProfilePictures" inverseEntity="Asset" syncable="YES"/>
     </entity>
     <entity name="Team" representedClassName=".MockTeam" syncable="YES">

--- a/Source/Public/MockTransportSession.h
+++ b/Source/Public/MockTransportSession.h
@@ -178,11 +178,8 @@ typedef ZMTransportResponse * _Nullable (^ZMCustomResponseGeneratorBlock)(ZMTran
 
 /// Support for services
 - (MockService *)insertServiceWithName:(NSString *)name
-                                handle:(NSString *)handle
-                              accentID:(NSInteger)accentID
                             identifier:(NSString *)identifier
-                              provider:(NSString *)provider
-                                assets:(NSSet<MockAsset *> *)assets;
+                              provider:(NSString *)provider;
 @end
 
 @interface MockTransportSession (IsTyping)


### PR DESCRIPTION
- Added the support for service and provider details.
- Added the support to remove the service from the conversation.

It is necessary for writing the integration tests on wire-ios-sync engine.