### PR TITLE
Added mock reachability

### DIFF
--- a/Source/MockReachability.m
+++ b/Source/MockReachability.m
@@ -1,0 +1,53 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+#import "MockReachability.h"
+
+@implementation MockReachability
+
+-(void)tearDown{
+    
+}
+
+-(BOOL)mayBeReachable{
+    return true;
+}
+
+-(BOOL)oldMayBeReachable{
+    return true;
+}
+
+-(BOOL)isMobileConnection{
+    return true;
+}
+
+-(BOOL)oldIsMobileConnection{
+    return true;
+}
+
+-(id)addReachabilityObserver:(id<ZMReachabilityObserver>)observer queue:(NSOperationQueue *)queue{
+    NSLog(@"%@ %@", observer, queue);
+    return self;
+}
+
+-(id)addReachabilityObserverOnQueue:(NSOperationQueue *)queue block:(ReachabilityObserverBlock)block{
+    NSLog(@"%@ %@", queue, block);
+    return self;
+}
+
+@end

--- a/Source/MockReachability.m
+++ b/Source/MockReachability.m
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
+// Copyright (C) 2018 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Source/MockTransportSession.m
+++ b/Source/MockTransportSession.m
@@ -28,6 +28,7 @@
 #import "MockEvent.h"
 #import "MockConnection.h"
 #import "MockPreKey.h"
+#import "MockReachability.h"
 #import "WireMockTransport/WireMockTransport-Swift.h"
 
 NSString * const ZMPushChannelStateChangeNotificationName = @"ZMPushChannelStateChangeNotification";
@@ -129,7 +130,8 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
         self.phoneNumbersWaitingForVerificationForProfile = [NSMutableSet set];
 
         self.emailsWaitingForVerificationForRegistration = [NSMutableSet set];
-
+        
+        self.reachability = [[MockReachability alloc] init];
         self.pushTokens = [NSMutableArray array];
         _nonCompletedRequests = [NSMutableArray array];
     }

--- a/Source/Public/MockReachability.h
+++ b/Source/Public/MockReachability.h
@@ -1,9 +1,19 @@
 //
-//  MockReachability.h
-//  WireMockTransport-ios
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
 //
-//  Created by Nicola Giancecchi on 13.02.18.
-//  Copyright © 2018 Zeta Project. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/Public/MockReachability.h
+++ b/Source/Public/MockReachability.h
@@ -1,0 +1,16 @@
+//
+//  MockReachability.h
+//  WireMockTransport-ios
+//
+//  Created by Nicola Giancecchi on 13.02.18.
+//  Copyright © 2018 Zeta Project. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+@import WireTransport;
+
+@interface MockReachability : NSObject<ReachabilityProvider, ReachabilityTearDown>  
+
+@end
+
+

--- a/Source/Public/MockTransportSession.h
+++ b/Source/Public/MockTransportSession.h
@@ -68,6 +68,8 @@ typedef ZMTransportResponse * _Nullable (^ZMCustomResponseGeneratorBlock)(ZMTran
 
 @property (nonatomic, readonly) NSArray *updateEvents;
 
+@property (nonatomic, readwrite) id<ReachabilityProvider,ReachabilityTearDown> reachability;
+
 + (NSString *)binaryDataTypeAsMIME:(NSString *)type;
 
 - (BOOL)waitForAllRequestsToCompleteWithTimeout:(NSTimeInterval)timeout;

--- a/WireMockTransport.xcodeproj/project.pbxproj
+++ b/WireMockTransport.xcodeproj/project.pbxproj
@@ -80,6 +80,8 @@
 		54C9023F1B7532DD007162A8 /* WireMockTransport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 54C902331B7532DD007162A8 /* WireMockTransport.framework */; };
 		54CE5E711B7534C8007F3065 /* ocmock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 54CE5E691B7534C4007F3065 /* ocmock.framework */; };
 		54FAE6821E3A025500E6DE42 /* MockTransportSessionObjectCreationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FAE6801E3A01F000E6DE42 /* MockTransportSessionObjectCreationTests.swift */; };
+		7C52BFF72033225500297DDA /* MockReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C52BFF52033225500297DDA /* MockReachability.h */; };
+		7C52BFF82033225500297DDA /* MockReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C52BFF62033225500297DDA /* MockReachability.m */; };
 		872A2EE01FFE761B00900B22 /* MockService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872A2EDF1FFE761B00900B22 /* MockService.swift */; };
 		872A2EE21FFE7EE700900B22 /* MockTransportSession+Services.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872A2EE11FFE7EE700900B22 /* MockTransportSession+Services.swift */; };
 		872A2EE41FFE85D000900B22 /* MockServicesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872A2EE31FFE85D000900B22 /* MockServicesTests.swift */; };
@@ -258,6 +260,8 @@
 		54C902641B7532F6007162A8 /* WireMockTransport.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = WireMockTransport.xcconfig; sourceTree = "<group>"; };
 		54CE5E691B7534C4007F3065 /* ocmock.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ocmock.framework; path = Carthage/Build/iOS/ocmock.framework; sourceTree = "<group>"; };
 		54FAE6801E3A01F000E6DE42 /* MockTransportSessionObjectCreationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockTransportSessionObjectCreationTests.swift; sourceTree = "<group>"; };
+		7C52BFF52033225500297DDA /* MockReachability.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockReachability.h; sourceTree = "<group>"; };
+		7C52BFF62033225500297DDA /* MockReachability.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MockReachability.m; sourceTree = "<group>"; };
 		872A2EDF1FFE761B00900B22 /* MockService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockService.swift; sourceTree = "<group>"; };
 		872A2EE11FFE7EE700900B22 /* MockTransportSession+Services.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockTransportSession+Services.swift"; sourceTree = "<group>"; };
 		872A2EE31FFE85D000900B22 /* MockServicesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockServicesTests.swift; sourceTree = "<group>"; };
@@ -412,6 +416,7 @@
 				54AE5A6E1B78FA43002757E9 /* MockTransportSession.h */,
 				541797661CE1FC0C00C7646D /* CustomResponseGenerator.swift */,
 				09E393F31BB0336A00F3EA1B /* MockPreKey.h */,
+				7C52BFF52033225500297DDA /* MockReachability.h */,
 				54AE5A701B78FA43002757E9 /* WireMockTransport.h */,
 			);
 			path = Public;
@@ -443,6 +448,7 @@
 		54C902351B7532DD007162A8 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				7C52BFF62033225500297DDA /* MockReachability.m */,
 				54AE5A4C1B78FA43002757E9 /* Helpers */,
 				54AE5A5A1B78FA43002757E9 /* MockTransportSession.m */,
 				F1782D8E1ED304CF00486BE3 /* MockTransportSession.swift */,
@@ -578,6 +584,7 @@
 				CE4750291C19F73500848CCB /* MockPersonalInvitation.h in Headers */,
 				CE89FED61C19865E0093C3B6 /* MockTransportSession+invitations.h in Headers */,
 				163EB0CE1FD1A658005B8D8D /* MockTransportSession+Broadcast.h in Headers */,
+				7C52BFF72033225500297DDA /* MockReachability.h in Headers */,
 				54AE5A891B78FA43002757E9 /* MockConnection.h in Headers */,
 				54AE5A791B78FA43002757E9 /* MockTransportSession+registration.h in Headers */,
 				54AE5A711B78FA43002757E9 /* MockTransportSession+assets.h in Headers */,
@@ -725,6 +732,7 @@
 				F1E9BC951E8519FC00D96342 /* MockUser.swift in Sources */,
 				F14741551EC462EB00A3688C /* MockMember.swift in Sources */,
 				547AC6361E377B5A001458FD /* MockUserClient.swift in Sources */,
+				7C52BFF82033225500297DDA /* MockReachability.m in Sources */,
 				09E393F81BB0339200F3EA1B /* MockPreKey.m in Sources */,
 				54AE5A741B78FA43002757E9 /* MockTransportSession+connections.m in Sources */,
 				163EB0CF1FD1A658005B8D8D /* MockTransportSession+Broadcast.m in Sources */,


### PR DESCRIPTION
## What's new in this PR?

I've added a mock of `ZMReachability` in order to pass the failing tests of https://github.com/wireapp/wire-ios-share-engine/pull/52 .