### PR TITLE
Added conversation access roles to conversations

### DIFF
--- a/Source/Helpers/MockTransportSession+conversations.m
+++ b/Source/Helpers/MockTransportSession+conversations.m
@@ -100,6 +100,8 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransport";
     }
     else if ([request matchesWithPath:@"/conversations/*/bots/*" method:ZMMethodDELETE]) {
         return [self processDeleteBotRequest:request];
+    } else if ([request matchesWithPath:@"/conversations/*/access" method:ZMMethodPUT]) {
+        return [self processAccessModeUpdateForConversation:[request RESTComponentAtIndex:1] payload:[request.payload asDictionary]];
     }
 
     return [ZMTransportResponse responseWithPayload:nil HTTPStatus:404 transportSessionError:nil];

--- a/Source/Helpers/MockTransportSession+conversations.swift
+++ b/Source/Helpers/MockTransportSession+conversations.swift
@@ -1,0 +1,60 @@
+////
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension MockTransportSession {
+
+    @objc(fetchConversationWithIdentifier:)
+    public func fetchConversation(with identifier: String) -> MockConversation? {
+        let request = MockConversation.sortedFetchRequest()
+        request.predicate = NSPredicate(format: "identifier == %@", identifier.lowercased())
+        let conversations = managedObjectContext.executeFetchRequestOrAssert(request) as? [MockConversation]
+        return conversations?.first
+    }
+
+    @objc(processAccessModeUpdateForConversation:payload:)
+    public func processAccessModeUpdate(for conversationId: String, payload: [String : AnyHashable]) -> ZMTransportResponse {
+        if let conversation = fetchConversation(with: conversationId) {
+
+            guard let accessRole = payload["access_role"] as? String else {
+                return ZMTransportResponse(payload: nil, httpStatus: 400, transportSessionError: nil)
+            }
+            guard let access = payload["access"] as? [String] else {
+                return ZMTransportResponse(payload: nil, httpStatus: 400, transportSessionError: nil)
+            }
+
+            conversation.accessRole = accessRole
+            conversation.accessMode = access
+
+            let responsePayload = [
+                "conversation" : conversation.identifier,
+                "type" : "conversation.access-update",
+                "time" : NSDate().transportString(),
+                "from" : selfUser.identifier,
+                "data" : [
+                    "access_role" : conversation.accessRole,
+                    "access" : conversation.accessMode
+                ]
+            ] as ZMTransportData
+            return ZMTransportResponse(payload: responsePayload, httpStatus: 200, transportSessionError: nil)
+        } else {
+            return ZMTransportResponse(payload: nil, httpStatus: 404, transportSessionError: nil)
+        }
+    }
+}

--- a/Source/Helpers/MockTransportSession+invitations.m
+++ b/Source/Helpers/MockTransportSession+invitations.m
@@ -55,7 +55,7 @@
     }
     NSString *message = [payload stringForKey:@"message"];
     if (message == nil) {
-        return [self errorResponseWithCode:400 reason:@"Missing \"invitee_name\" field"];
+        return [self errorResponseWithCode:400 reason:@"Missing \"message\" field"];
     }
     
     NSString *inviteeEmail = [payload optionalStringForKey:@"email"];

--- a/Source/MockTransportSession.m
+++ b/Source/MockTransportSession.m
@@ -520,14 +520,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
     
 }
 
-- (MockConversation *)fetchConversationWithIdentifier:(NSString *)conversationID;
-{
-    NSFetchRequest *request = [MockConversation sortedFetchRequest];
-    request.predicate = [NSPredicate predicateWithFormat:@"identifier == %@", conversationID.lowercaseString];
-    NSArray *conversations = [self.managedObjectContext executeFetchRequestOrAssert:request];
-    NSAssert(conversations.count == 1, @"Not found");
-    return conversations[0];
-}
+
 
 
 - (MockUser *)fetchUserWithIdentifier:(NSString *)userID;

--- a/Source/Model/MockConversation.m
+++ b/Source/Model/MockConversation.m
@@ -48,6 +48,8 @@
 @dynamic otrMuted;
 @dynamic otrMutedRef;
 @dynamic team;
+@dynamic accessRole;
+@dynamic accessMode;
 
 + (instancetype)insertConversationIntoContext:(NSManagedObjectContext *)moc withSelfUser:(MockUser *)selfUser creator:(MockUser *)creator otherUsers:(NSArray *)otherUsers type:(ZMTConversationType)type
 {
@@ -160,7 +162,8 @@
     data[@"name"] = self.name ?: [NSNull null];
     data[@"id"] = self.identifier ?: [NSNull null];
     data[@"type"] = self.transportConversationType;
-    
+    data[@"access"] = self.accessMode ?: [NSNull null];
+    data[@"access_role"] = self.accessRole ?: [NSNull null];
     data[@"team"] = self.team.identifier ?: [NSNull null];
 
     NSMutableDictionary *members = [NSMutableDictionary dictionary];

--- a/Source/Model/MockConversation.m
+++ b/Source/Model/MockConversation.m
@@ -168,7 +168,7 @@
     data[@"type"] = self.transportConversationType;
     data[@"access"] = self.accessMode;
     data[@"access_role"] = self.accessRole;
-    data[@"team"] = self.team.identifier;
+    data[@"team"] = self.team.identifier ?: [NSNull null];
 
     NSMutableDictionary *members = [NSMutableDictionary dictionary];
     data[@"members"] = members;

--- a/Source/Model/MockConversation.m
+++ b/Source/Model/MockConversation.m
@@ -62,6 +62,8 @@
     [conversation addUsersByUser:creator addedUsers:addedUsers.array];
     conversation.identifier = [NSUUID createUUID].transportString;
     conversation.creator = creator;
+    conversation.accessMode = [MockConversation defaultAccessModeWithConversationType:type team:nil];
+    conversation.accessRole = [MockConversation defaultAccessRoleWithConversationType:type team:nil];
     [conversation.mutableActiveUsers addObject:creator];
     return conversation;
 }
@@ -76,6 +78,8 @@
     conversation.identifier = [NSUUID createUUID].transportString;
     conversation.creator = creator;
     [conversation.mutableActiveUsers addObject:creator];
+    conversation.accessMode = [MockConversation defaultAccessModeWithConversationType:type team:nil];
+    conversation.accessRole = [MockConversation defaultAccessRoleWithConversationType:type team:nil];
     return conversation;
 }
 
@@ -162,9 +166,9 @@
     data[@"name"] = self.name ?: [NSNull null];
     data[@"id"] = self.identifier ?: [NSNull null];
     data[@"type"] = self.transportConversationType;
-    data[@"access"] = self.accessMode ?: [NSNull null];
-    data[@"access_role"] = self.accessRole ?: [NSNull null];
-    data[@"team"] = self.team.identifier ?: [NSNull null];
+    data[@"access"] = self.accessMode;
+    data[@"access_role"] = self.accessRole;
+    data[@"team"] = self.team.identifier;
 
     NSMutableDictionary *members = [NSMutableDictionary dictionary];
     data[@"members"] = members;

--- a/Source/Model/MockConversation.swift
+++ b/Source/Model/MockConversation.swift
@@ -23,11 +23,35 @@ extension MockConversation {
     @objc public static func insertConversationInto(context: NSManagedObjectContext, withCreator creator: MockUser, forTeam team: MockTeam, users:[MockUser]) -> MockConversation {
         let conversation = NSEntityDescription.insertNewObject(forEntityName: "Conversation", into: context) as! MockConversation
         conversation.type = .group
+        (conversation.accessMode, conversation.accessRole) = defaultAccess(conversationType: .group, team: team)
         conversation.team = team
         conversation.identifier = UUID.create().transportString()
         conversation.creator = creator
         conversation.mutableOrderedSetValue(forKey: #keyPath(MockConversation.activeUsers)).addObjects(from: users)
         return conversation
+    }
+
+    @objc public static func defaultAccessMode(conversationType: ZMTConversationType, team: MockTeam?) -> [String] {
+        let (accessMode, _) = defaultAccess(conversationType: conversationType, team: team)
+        return accessMode
+    }
+
+    @objc public static func defaultAccessRole(conversationType: ZMTConversationType, team: MockTeam?) -> String {
+        let (_, accessRole) = defaultAccess(conversationType: conversationType, team: team)
+        return accessRole
+    }
+
+    public static func defaultAccess(conversationType: ZMTConversationType, team: MockTeam?) -> ([String], String) {
+        switch (team, conversationType) {
+        case (.some, .group):
+            return (["invite"], "verified")
+        case (.some, _):
+            return (["private"], "private")
+        case (.none, .group):
+            return (["invite"], "verified")
+        case (.none, _):
+            return (["private"], "private")
+        }
     }
 }
 

--- a/Source/Model/MockConversation.swift
+++ b/Source/Model/MockConversation.swift
@@ -44,11 +44,11 @@ extension MockConversation {
     public static func defaultAccess(conversationType: ZMTConversationType, team: MockTeam?) -> ([String], String) {
         switch (team, conversationType) {
         case (.some, .group):
-            return (["invite"], "verified")
+            return (["invite"], "activated")
         case (.some, _):
             return (["private"], "private")
         case (.none, .group):
-            return (["invite"], "verified")
+            return (["invite"], "activated")
         case (.none, _):
             return (["private"], "private")
         }

--- a/Source/Model/MockTransportSession.xcdatamodeld/TestTransportSession.xcdatamodel/contents
+++ b/Source/Model/MockTransportSession.xcdatamodeld/TestTransportSession.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="13241" systemVersion="17C88" minimumToolsVersion="Xcode 4.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="13241" systemVersion="17D102" minimumToolsVersion="Xcode 4.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Asset" representedClassName="MockAsset" syncable="YES">
         <attribute name="contentType" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="conversation" optional="YES" attributeType="String" syncable="YES"/>
@@ -17,6 +17,8 @@
         <relationship name="to" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="connectionsTo" inverseEntity="User" syncable="YES"/>
     </entity>
     <entity name="Conversation" representedClassName="MockConversation" syncable="YES">
+        <attribute name="accessMode" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="accessRole" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="identifier" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="otrArchived" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
@@ -136,7 +138,7 @@
     <elements>
         <element name="Asset" positionX="0" positionY="0" width="128" height="135"/>
         <element name="Connection" positionX="0" positionY="0" width="128" height="135"/>
-        <element name="Conversation" positionX="0" positionY="0" width="128" height="240"/>
+        <element name="Conversation" positionX="0" positionY="0" width="128" height="270"/>
         <element name="Event" positionX="0" positionY="0" width="128" height="150"/>
         <element name="Member" positionX="18" positionY="162" width="128" height="90"/>
         <element name="PersonalInvitation" positionX="0" positionY="0" width="128" height="135"/>

--- a/Source/Public/MockConversation.h
+++ b/Source/Public/MockConversation.h
@@ -42,6 +42,8 @@ typedef NS_ENUM(int16_t, ZMTConversationType) {
 @property (nonatomic) BOOL otrMuted;
 
 @property (nonatomic, nullable) MockUser *creator;
+@property (nonatomic, nullable) NSArray<NSString *> *accessMode;
+@property (nonatomic, nullable) NSString* accessRole;
 @property (nonatomic, nonnull) NSString *identifier;
 @property (nonatomic, nonnull) NSString *selfIdentifier;
 @property (nonatomic, readonly, nullable) NSString *name;

--- a/Source/Public/MockConversation.h
+++ b/Source/Public/MockConversation.h
@@ -42,8 +42,8 @@ typedef NS_ENUM(int16_t, ZMTConversationType) {
 @property (nonatomic) BOOL otrMuted;
 
 @property (nonatomic, nullable) MockUser *creator;
-@property (nonatomic, nullable) NSArray<NSString *> *accessMode;
-@property (nonatomic, nullable) NSString* accessRole;
+@property (nonatomic, nonnull) NSArray<NSString *> *accessMode;
+@property (nonatomic, nonnull) NSString* accessRole;
 @property (nonatomic, nonnull) NSString *identifier;
 @property (nonatomic, nonnull) NSString *selfIdentifier;
 @property (nonatomic, readonly, nullable) NSString *name;

--- a/Tests/MockTransportSessionConversationAccessTests.swift
+++ b/Tests/MockTransportSessionConversationAccessTests.swift
@@ -53,7 +53,7 @@ class MockTransportSessionConversationAccessTests: MockTransportSessionTests {
     func testThatSettingAccessModeReturnsErrorWhenMissingAccess() {
         // given
         let payload = [
-            "access_role": "verified",
+            "access_role": "activated",
         ] as ZMTransportData
 
         // when

--- a/Tests/MockTransportSessionConversationAccessTests.swift
+++ b/Tests/MockTransportSessionConversationAccessTests.swift
@@ -1,0 +1,103 @@
+////
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+class MockTransportSessionConversationAccessTests: MockTransportSessionTests {
+
+    var team: MockTeam!
+    var selfUser: MockUser!
+    var conversation: MockConversation!
+
+    override func setUp() {
+        super.setUp()
+        sut.performRemoteChanges { session in
+            self.selfUser = session.insertSelfUser(withName: "me")
+            self.team = session.insertTeam(withName: "A Team", isBound: true)
+            self.conversation = session.insertTeamConversation(to: self.team, with: [session.insertUser(withName: "some")], creator: self.selfUser)
+
+        }
+        XCTAssert(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+    }
+
+    override func tearDown() {
+        team = nil
+        selfUser = nil
+        conversation = nil
+        super.tearDown()
+    }
+
+    func testThatSettingAccessModeReturnsErrorWhenConversationDoesNotExist() {
+        // when
+        let response = self.response(forPayload: [:] as ZMTransportData , path: "/conversations/123456/access", method: .methodPUT)
+
+        // then
+        XCTAssertEqual(response?.httpStatus, 404)
+    }
+
+    func testThatSettingAccessModeReturnsErrorWhenMissingAccess() {
+        // given
+        let payload = [
+            "access_role": "verified",
+        ] as ZMTransportData
+
+        // when
+        let response = self.response(forPayload: payload , path: "/conversations/\(self.conversation.identifier)/access", method: .methodPUT)
+
+        // then
+        XCTAssertEqual(response?.httpStatus, 400)
+    }
+
+    func testThatSettingAccessModeReturnsErrorWhenMissingAccessRole() {
+        // given
+        let payload = [
+            "access": ["invite"],
+            ] as ZMTransportData
+
+        // when
+        let response = self.response(forPayload: payload , path: "/conversations/\(self.conversation.identifier)/access", method: .methodPUT)
+
+        // then
+        XCTAssertEqual(response?.httpStatus, 400)
+    }
+
+    func testThatSettingAccessModeReturnsCorrectDataInPayload() {
+
+        let role = "team"
+        let access = ["invite", "code"]
+        // given
+        let payload = [
+            "access_role": role,
+            "access": access,
+            ] as ZMTransportData
+
+        // when
+        let response = self.response(forPayload: payload , path: "/conversations/\(self.conversation.identifier)/access", method: .methodPUT)
+
+        // then
+        XCTAssertEqual(response?.httpStatus, 200)
+        guard let receivedPayload = response?.payload as? [String: Any] else { XCTFail(); return }
+        guard let payloadData = receivedPayload["data"] as? [String: Any] else { XCTFail(); return }
+        guard let responseRole = payloadData["access_role"] as? String else { XCTFail(); return }
+        guard let responseAccess = payloadData["access"] as? [String] else { XCTFail(); return }
+
+
+        XCTAssertEqual(responseRole, role)
+        XCTAssertEqual(responseAccess, access)
+    }
+}

--- a/Tests/MockTransportSessionConversationsTests.swift
+++ b/Tests/MockTransportSessionConversationsTests.swift
@@ -42,7 +42,7 @@ class MockTransportSessionConversationsTests_Swift: MockTransportSessionTests {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         XCTAssertEqual(conversation.accessMode, ["invite"])
-        XCTAssertEqual(conversation.accessRole, "verified")
+        XCTAssertEqual(conversation.accessRole, "activated")
     }
 
     func testThatDefaultAccessModeForTeamGroupConversationIsCorrect() {
@@ -56,6 +56,6 @@ class MockTransportSessionConversationsTests_Swift: MockTransportSessionTests {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         XCTAssertEqual(conversation.accessMode, ["invite"])
-        XCTAssertEqual(conversation.accessRole, "verified")
+        XCTAssertEqual(conversation.accessRole, "activated")
     }
 }

--- a/Tests/MockTransportSessionConversationsTests.swift
+++ b/Tests/MockTransportSessionConversationsTests.swift
@@ -1,0 +1,61 @@
+////
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+class MockTransportSessionConversationsTests_Swift: MockTransportSessionTests {
+    func testThatDefaultAccessModeForOneToOneConversationIsCorrect() {
+        var conversation: MockConversation!
+        sut.performRemoteChanges { session in
+            let selfUser = session.insertSelfUser(withName: "me")
+            conversation = session.insertOneOnOneConversation(withSelfUser: selfUser, otherUser: session.insertUser(withName: "friend"))
+        }
+
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        XCTAssertEqual(conversation.accessMode, ["private"])
+        XCTAssertEqual(conversation.accessRole, "private")
+    }
+
+    func testThatDefaultAccessModeForGroupConversationIsCorrect() {
+        var conversation: MockConversation!
+        sut.performRemoteChanges { session in
+            let selfUser = session.insertSelfUser(withName: "me")
+            conversation = session.insertGroupConversation(withSelfUser: selfUser, otherUsers: [session.insertUser(withName: "friend"), session.insertUser(withName: "other friend")])
+        }
+
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        XCTAssertEqual(conversation.accessMode, ["invite"])
+        XCTAssertEqual(conversation.accessRole, "verified")
+    }
+
+    func testThatDefaultAccessModeForTeamGroupConversationIsCorrect() {
+        var conversation: MockConversation!
+        sut.performRemoteChanges { session in
+            let team = session.insertTeam(withName: "Name", isBound: true)
+            let selfUser = session.insertSelfUser(withName: "me")
+            conversation = session.insertTeamConversation(to: team, with: [session.insertUser(withName: "friend"), session.insertUser(withName: "other friend")], creator: selfUser)
+        }
+
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        XCTAssertEqual(conversation.accessMode, ["invite"])
+        XCTAssertEqual(conversation.accessRole, "verified")
+    }
+}

--- a/Tests/MockTransportSessionTests.m
+++ b/Tests/MockTransportSessionTests.m
@@ -481,7 +481,7 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransportTests";
     [conversation.managedObjectContext performBlockAndWait:^{
         NSDictionary *dict = (id) data;
         XCTAssertTrue([dict isKindOfClass:[NSDictionary class]]);
-        NSArray *keys = @[@"creator", @"id", @"members", @"name", @"type", @"team"];
+        NSArray *keys = @[@"creator", @"id", @"members", @"name", @"type", @"team", @"access_role", @"access"];
         AssertDictionaryHasKeys(dict, keys);
         
         XCTAssertEqualObjects(dict[@"creator"], conversation.creator ? conversation.creator.identifier: [NSNull null]);

--- a/WireMockTransport.xcodeproj/project.pbxproj
+++ b/WireMockTransport.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		CE89FED61C19865E0093C3B6 /* MockTransportSession+invitations.h in Headers */ = {isa = PBXBuildFile; fileRef = CE89FED41C19865E0093C3B6 /* MockTransportSession+invitations.h */; };
 		CE89FED71C19865E0093C3B6 /* MockTransportSession+invitations.m in Sources */ = {isa = PBXBuildFile; fileRef = CE89FED51C19865E0093C3B6 /* MockTransportSession+invitations.m */; };
 		F119FC1A20444F9C00969615 /* MockTransportSessionConversationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F119FC1920444F9C00969615 /* MockTransportSessionConversationsTests.swift */; };
+		F119FC1C2044551200969615 /* MockTransportSessionConversationAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F119FC1B2044551200969615 /* MockTransportSessionConversationAccessTests.swift */; };
 		F14741531EC45F8900A3688C /* MockTeam.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14741521EC45F8900A3688C /* MockTeam.swift */; };
 		F14741551EC462EB00A3688C /* MockMember.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14741541EC462EB00A3688C /* MockMember.swift */; };
 		F149F80E1ECC75C100B05E16 /* MockTransportSessionTeamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F149F80D1ECC75C100B05E16 /* MockTransportSessionTeamTests.swift */; };
@@ -283,6 +284,7 @@
 		CE89FED41C19865E0093C3B6 /* MockTransportSession+invitations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MockTransportSession+invitations.h"; sourceTree = "<group>"; };
 		CE89FED51C19865E0093C3B6 /* MockTransportSession+invitations.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MockTransportSession+invitations.m"; sourceTree = "<group>"; };
 		F119FC1920444F9C00969615 /* MockTransportSessionConversationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTransportSessionConversationsTests.swift; sourceTree = "<group>"; };
+		F119FC1B2044551200969615 /* MockTransportSessionConversationAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTransportSessionConversationAccessTests.swift; sourceTree = "<group>"; };
 		F14741521EC45F8900A3688C /* MockTeam.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockTeam.swift; sourceTree = "<group>"; };
 		F14741541EC462EB00A3688C /* MockMember.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockMember.swift; sourceTree = "<group>"; };
 		F149F80D1ECC75C100B05E16 /* MockTransportSessionTeamTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockTransportSessionTeamTests.swift; sourceTree = "<group>"; };
@@ -501,6 +503,7 @@
 				F149F80D1ECC75C100B05E16 /* MockTransportSessionTeamTests.swift */,
 				F1782D901ED30F9900486BE3 /* MockTransportSessionTeamEventsTests.swift */,
 				163EB0D01FD1BDD4005B8D8D /* MockTransportSessionBroadcastTests.swift */,
+				F119FC1B2044551200969615 /* MockTransportSessionConversationAccessTests.swift */,
 				F190E0931E8C0218003E81F8 /* MockUserTests.swift */,
 				872A2EE31FFE85D000900B22 /* MockServicesTests.swift */,
 				54C902431B7532DD007162A8 /* Supporting Files */,
@@ -785,6 +788,7 @@
 				F1782D911ED30F9900486BE3 /* MockTransportSessionTeamEventsTests.swift in Sources */,
 				541797651CE1F86500C7646D /* MockTransportSessionCancelationTests.swift in Sources */,
 				54AE5AA41B78FA62002757E9 /* MockTransportSessionConnectionsTests.m in Sources */,
+				F119FC1C2044551200969615 /* MockTransportSessionConversationAccessTests.swift in Sources */,
 				54FAE6821E3A025500E6DE42 /* MockTransportSessionObjectCreationTests.swift in Sources */,
 				F190E0951E8C0286003E81F8 /* MockUserTests.swift in Sources */,
 				CE471AF31C19AC670040802B /* MockTransportSessionInvitationTests.m in Sources */,

--- a/WireMockTransport.xcodeproj/project.pbxproj
+++ b/WireMockTransport.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		CE89FED31C19780D0093C3B6 /* MockPersonalInvitation.m in Sources */ = {isa = PBXBuildFile; fileRef = CE89FECF1C19780D0093C3B6 /* MockPersonalInvitation.m */; };
 		CE89FED61C19865E0093C3B6 /* MockTransportSession+invitations.h in Headers */ = {isa = PBXBuildFile; fileRef = CE89FED41C19865E0093C3B6 /* MockTransportSession+invitations.h */; };
 		CE89FED71C19865E0093C3B6 /* MockTransportSession+invitations.m in Sources */ = {isa = PBXBuildFile; fileRef = CE89FED51C19865E0093C3B6 /* MockTransportSession+invitations.m */; };
+		F119FC1A20444F9C00969615 /* MockTransportSessionConversationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F119FC1920444F9C00969615 /* MockTransportSessionConversationsTests.swift */; };
 		F14741531EC45F8900A3688C /* MockTeam.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14741521EC45F8900A3688C /* MockTeam.swift */; };
 		F14741551EC462EB00A3688C /* MockMember.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14741541EC462EB00A3688C /* MockMember.swift */; };
 		F149F80E1ECC75C100B05E16 /* MockTransportSessionTeamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F149F80D1ECC75C100B05E16 /* MockTransportSessionTeamTests.swift */; };
@@ -118,6 +119,7 @@
 		F1519B5C1EC09D3100AD4E33 /* MockTransportSessionAssetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1519B5B1EC09D3100AD4E33 /* MockTransportSessionAssetsTests.swift */; };
 		F1519B5E1EC0A30100AD4E33 /* MockTransportSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1519B5D1EC0A30100AD4E33 /* MockTransportSessionTests.swift */; };
 		F1519B601EC0A6FC00AD4E33 /* MockTransportSession+assets.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1519B591EC09C0100AD4E33 /* MockTransportSession+assets.swift */; };
+		F16C8BED20443F4A00677D31 /* MockTransportSession+conversations.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16C8BEC20443F4A00677D31 /* MockTransportSession+conversations.swift */; };
 		F1782D701ED2E9E700486BE3 /* MockTeamEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1782D6F1ED2E9E700486BE3 /* MockTeamEvent.swift */; };
 		F1782D8F1ED304CF00486BE3 /* MockTransportSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1782D8E1ED304CF00486BE3 /* MockTransportSession.swift */; };
 		F1782D911ED30F9900486BE3 /* MockTransportSessionTeamEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1782D901ED30F9900486BE3 /* MockTransportSessionTeamEventsTests.swift */; };
@@ -280,6 +282,7 @@
 		CE89FECF1C19780D0093C3B6 /* MockPersonalInvitation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MockPersonalInvitation.m; sourceTree = "<group>"; };
 		CE89FED41C19865E0093C3B6 /* MockTransportSession+invitations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MockTransportSession+invitations.h"; sourceTree = "<group>"; };
 		CE89FED51C19865E0093C3B6 /* MockTransportSession+invitations.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MockTransportSession+invitations.m"; sourceTree = "<group>"; };
+		F119FC1920444F9C00969615 /* MockTransportSessionConversationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTransportSessionConversationsTests.swift; sourceTree = "<group>"; };
 		F14741521EC45F8900A3688C /* MockTeam.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockTeam.swift; sourceTree = "<group>"; };
 		F14741541EC462EB00A3688C /* MockMember.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockMember.swift; sourceTree = "<group>"; };
 		F149F80D1ECC75C100B05E16 /* MockTransportSessionTeamTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockTransportSessionTeamTests.swift; sourceTree = "<group>"; };
@@ -289,6 +292,7 @@
 		F1519B591EC09C0100AD4E33 /* MockTransportSession+assets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MockTransportSession+assets.swift"; sourceTree = "<group>"; };
 		F1519B5B1EC09D3100AD4E33 /* MockTransportSessionAssetsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockTransportSessionAssetsTests.swift; sourceTree = "<group>"; };
 		F1519B5D1EC0A30100AD4E33 /* MockTransportSessionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockTransportSessionTests.swift; sourceTree = "<group>"; };
+		F16C8BEC20443F4A00677D31 /* MockTransportSession+conversations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockTransportSession+conversations.swift"; sourceTree = "<group>"; };
 		F1782D6F1ED2E9E700486BE3 /* MockTeamEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockTeamEvent.swift; sourceTree = "<group>"; };
 		F1782D8E1ED304CF00486BE3 /* MockTransportSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockTransportSession.swift; sourceTree = "<group>"; };
 		F1782D901ED30F9900486BE3 /* MockTransportSessionTeamEventsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockTransportSessionTeamEventsTests.swift; sourceTree = "<group>"; };
@@ -354,6 +358,7 @@
 				54AE5A501B78FA43002757E9 /* MockTransportSession+connections.m */,
 				54AE5A511B78FA43002757E9 /* MockTransportSession+conversations.h */,
 				54AE5A521B78FA43002757E9 /* MockTransportSession+conversations.m */,
+				F16C8BEC20443F4A00677D31 /* MockTransportSession+conversations.swift */,
 				54AE5A531B78FA43002757E9 /* MockTransportSession+PushToken.h */,
 				54AE5A541B78FA43002757E9 /* MockTransportSession+PushToken.m */,
 				54AE5A551B78FA43002757E9 /* MockTransportSession+registration.h */,
@@ -477,6 +482,7 @@
 				54AE5A931B78FA62002757E9 /* MockTransportSessionAPNSTokenTests.m */,
 				54AE5A951B78FA62002757E9 /* MockTransportSessionConnectionsTests.m */,
 				54AE5A961B78FA62002757E9 /* MockTransportSessionConversationsTests.m */,
+				F119FC1920444F9C00969615 /* MockTransportSessionConversationsTests.swift */,
 				54AE5A971B78FA62002757E9 /* MockTransportSessionEmailPhoneVerificationTests.m */,
 				54AE5A991B78FA62002757E9 /* MockTransportSessionLoginTests.m */,
 				54AE5A9A1B78FA62002757E9 /* MockTransportSessionPushChannelTests.m */,
@@ -721,6 +727,7 @@
 				54AE5A7A1B78FA43002757E9 /* MockTransportSession+registration.m in Sources */,
 				F14741531EC45F8900A3688C /* MockTeam.swift in Sources */,
 				F1519B601EC0A6FC00AD4E33 /* MockTransportSession+assets.swift in Sources */,
+				F16C8BED20443F4A00677D31 /* MockTransportSession+conversations.swift in Sources */,
 				5425EF021E1E339B006D7A01 /* MockTransportSession+search.m in Sources */,
 				CE89FED71C19865E0093C3B6 /* MockTransportSession+invitations.m in Sources */,
 				09BCDB6A1BC7CFFC0020DCC7 /* MockTransportSession+OTR.m in Sources */,
@@ -787,6 +794,7 @@
 				54AE5AA21B78FA62002757E9 /* MockTransportSessionAPNSTokenTests.m in Sources */,
 				872A2EE41FFE85D000900B22 /* MockServicesTests.swift in Sources */,
 				54AE5AA91B78FA62002757E9 /* MockTransportSessionPushChannelTests.m in Sources */,
+				F119FC1A20444F9C00969615 /* MockTransportSessionConversationsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## What's new in this PR?

### Issues

To be able to test access roles we need to add support for it on mock transport. Also we need to handle changes for the access roles through designated endpoint.

### Solutions

Added default values for conversation access role and mode. They are slightly different in team and group conversations.
