### PR TITLE
Use update event enum from transport framework

### DIFF
--- a/Source/Conversations/MockConversation.h
+++ b/Source/Conversations/MockConversation.h
@@ -89,7 +89,6 @@ typedef NS_ENUM(int16_t, ZMTConversationType) {
                                        isInline:(BOOL)isInline;
 
 - (nonnull MockEvent *)insertKnockFromUser:(nonnull MockUser *)fromUser nonce:(nonnull NSUUID *)nonce;
-- (nonnull MockEvent *)insertHotKnockFromUser:(nonnull MockUser *)fromUser nonce:(nonnull NSUUID *)nonce ref:(nonnull NSString *)eventID;
 - (nonnull MockEvent *)insertTypingEventFromUser:(nonnull MockUser *)fromUser isTyping:(BOOL)isTyping;
 - (nonnull MockEvent *)remotelyArchiveFromUser:(nonnull MockUser *)fromUser referenceDate:(nonnull NSDate *)referenceDate;
 - (nonnull MockEvent *)remotelyClearHistoryFromUser:(nonnull MockUser *)fromUser referenceDate:(nonnull NSDate *)referenceDate;

--- a/Source/Conversations/MockConversation.m
+++ b/Source/Conversations/MockConversation.m
@@ -89,21 +89,18 @@
     return [self insertConversationIntoContext:moc withSelfUser:creator creator:creator otherUsers:otherUsers type:type];
 }
 
-- (MockEvent *)eventIfNeededByUser:(MockUser *)byUser type:(ZMTUpdateEventType)type data:(id<ZMTransportData>)data
+- (MockEvent *)eventIfNeededByUser:(MockUser *)byUser type:(ZMUpdateEventType)type data:(id<ZMTransportData>)data
 {
-    NSArray *eventTypesWithPushOnInsert = @[@(ZMTUpdateEventConversationAssetAdd),
-                                            @(ZMTUpdateEventConversationMessageAdd),
-                                            @(ZMTUpdateEventConversationClientMessageAdd),
-                                            @(ZMTUpdateEventConversationOTRMessageAdd),
-                                            @(ZMTUpdateEventConversationOTRAssetAdd),
-                                            @(ZMTUpdateEventConversationCreate),
-                                            @(ZMTUpdateEventConversationMemberJoin),
-                                            @(ZMTUpdateEventConversationConnectRequest),
-                                            @(ZMTUpdateEventConversationVoiceChannelDeactivate),
-                                            @(ZMTUpdateEventCallState),
-                                            @(ZMTUpdateEventConversationKnock),
-                                            @(ZMTUpdateEventConversationHotKnock),
-                                            @(ZMTUpdateEventConversationMemberUpdate)];
+    NSArray *eventTypesWithPushOnInsert = @[@(ZMUpdateEventTypeConversationAssetAdd),
+                                            @(ZMUpdateEventTypeConversationMessageAdd),
+                                            @(ZMUpdateEventTypeConversationClientMessageAdd),
+                                            @(ZMUpdateEventTypeConversationOtrMessageAdd),
+                                            @(ZMUpdateEventTypeConversationOtrAssetAdd),
+                                            @(ZMUpdateEventTypeConversationCreate),
+                                            @(ZMUpdateEventTypeConversationMemberJoin),
+                                            @(ZMUpdateEventTypeConversationConnectRequest),
+                                            @(ZMUpdateEventTypeConversationKnock),
+                                            @(ZMUpdateEventTypeConversationMemberUpdate)];
     
 
     if(self.isInserted && ![eventTypesWithPushOnInsert containsObject:@(type)]) {
@@ -220,7 +217,7 @@
 
 - (MockEvent *)insertClientMessageFromUser:(MockUser *)fromUser data:(NSData *)data
 {
-    return [self eventIfNeededByUser:fromUser type:ZMTUpdateEventConversationClientMessageAdd data:[data base64EncodedStringWithOptions:0]];
+    return [self eventIfNeededByUser:fromUser type:ZMUpdateEventTypeConversationClientMessageAdd data:[data base64EncodedStringWithOptions:0]];
 }
 
 
@@ -236,7 +233,7 @@
                                 @"recipient": toClient.identifier,
                                 @"text": [data base64EncodedStringWithOptions:0]
                                 };
-    return [self eventIfNeededByUser:fromClient.user type:ZMTUpdateEventConversationOTRMessageAdd data:eventData];
+    return [self eventIfNeededByUser:fromClient.user type:ZMUpdateEventTypeConversationOtrMessageAdd data:eventData];
 }
 
 - (MockEvent *)encryptAndInsertDataFromClient:(MockUserClient *)fromClient
@@ -268,21 +265,21 @@
                                 @"key": [metaData base64EncodedStringWithOptions:0],
                                 @"data": imageData != nil && isInline ? [imageData base64EncodedStringWithOptions:0] : [NSNull null]
                                 };
-    return [self eventIfNeededByUser:fromClient.user type:ZMTUpdateEventConversationOTRAssetAdd data:eventData];
+    return [self eventIfNeededByUser:fromClient.user type:ZMUpdateEventTypeConversationOtrAssetAdd data:eventData];
 }
 
 - (MockEvent *)remotelyArchiveFromUser:(MockUser *)fromUser referenceDate:(NSDate *)referenceDate
 {
     self.otrArchivedRef = referenceDate.transportString;
     self.otrArchived = YES;
-    return [self eventIfNeededByUser:fromUser type:ZMTUpdateEventConversationMemberUpdate data:(id<ZMTransportData>)self.selfInfoDictionary];
+    return [self eventIfNeededByUser:fromUser type:ZMUpdateEventTypeConversationMemberUpdate data:(id<ZMTransportData>)self.selfInfoDictionary];
 }
 
 - (MockEvent *)remotelyClearHistoryFromUser:(MockUser *)fromUser referenceDate:(NSDate *)referenceDate
 {
     self.otrArchivedRef = referenceDate.transportString;
     self.otrArchived = YES;
-    return [self eventIfNeededByUser:fromUser type:ZMTUpdateEventConversationMemberUpdate data:(id<ZMTransportData>)self.selfInfoDictionary];
+    return [self eventIfNeededByUser:fromUser type:ZMUpdateEventTypeConversationMemberUpdate data:(id<ZMTransportData>)self.selfInfoDictionary];
 }
 
 - (MockEvent *)remotelyDeleteFromUser:(MockUser *)fromUser referenceDate:(NSDate *)referenceDate
@@ -292,25 +289,7 @@
 
 - (MockEvent *)insertKnockFromUser:(MockUser *)fromUser nonce:(NSUUID *)nonce;
 {
-    return [self eventIfNeededByUser:fromUser type:ZMTUpdateEventConversationKnock data:@{@"nonce": nonce.transportString}];
-}
-
-- (MockEvent *)insertHotKnockFromUser:(MockUser *)fromUser nonce:(NSUUID *)nonce ref:(NSString *)eventID
-{
-    NSDictionary *payload;
-    if (eventID) {
-        payload = @{
-                    @"nonce": nonce.transportString,
-                    @"ref": eventID
-                    };
-    }
-    else {
-        payload = @{
-                    @"nonce": nonce.transportString
-                    };
-    }
-    
-    return [self eventIfNeededByUser:fromUser type:ZMTUpdateEventConversationHotKnock data:payload];
+    return [self eventIfNeededByUser:fromUser type:ZMUpdateEventTypeConversationKnock data:@{@"nonce": nonce.transportString}];
 }
 
 - (void)insertImageEventsFromUser:(MockUser *)fromUser;
@@ -326,7 +305,7 @@
 {
     NSDictionary *data = @{@"status": isTyping ? @"started" : @"stopped"};
     
-    return [self eventIfNeededByUser:fromUser type:ZMTUpdateEventConversationTyping data:data];
+    return [self eventIfNeededByUser:fromUser type:ZMUpdateEventTypeConversationTyping data:data];
 }
 
 
@@ -395,7 +374,7 @@
                            return [obj identifier];
                        }],
                        };
-    return [self eventIfNeededByUser:byUser type:ZMTUpdateEventConversationMemberJoin data:data];
+    return [self eventIfNeededByUser:byUser type:ZMUpdateEventTypeConversationMemberJoin data:data];
 }
 
 - (MockEvent *)connectRequestByUser:(MockUser *)byUser toUser:(MockUser *)user message:(NSString *)message
@@ -406,7 +385,7 @@
                            @"name" : user.name,
                            @"recipiend" : user.identifier
                            };
-    return [self eventIfNeededByUser:byUser type:ZMTUpdateEventConversationConnectRequest data:data];
+    return [self eventIfNeededByUser:byUser type:ZMUpdateEventTypeConversationConnectRequest data:data];
 }
 
 - (MockEvent *)removeUsersByUser:(MockUser *)byUser removedUser:(MockUser *)removedUser;
@@ -414,13 +393,13 @@
     [self.mutableActiveUsers removeObject:removedUser];
     
     NSDictionary *data = @{@"user_ids" : @[removedUser.identifier] };
-    return [self eventIfNeededByUser:byUser type:ZMTUpdateEventConversationMemberLeave data:data];
+    return [self eventIfNeededByUser:byUser type:ZMUpdateEventTypeConversationMemberLeave data:data];
 }
 
 -(MockEvent *)changeNameByUser:(MockUser *)user name:(NSString *)name
 {
     [self setValue:name forKey:@"name"];
-    return [self eventIfNeededByUser:user type:ZMTUpdateEventConversationRename data:@{@"name" : name}];
+    return [self eventIfNeededByUser:user type:ZMUpdateEventTypeConversationRename data:@{@"name" : name}];
 
 }
 
@@ -445,7 +424,7 @@
                                    }
                            };
     
-    return [self eventIfNeededByUser:user type:ZMTUpdateEventConversationAssetAdd data:payload];
+    return [self eventIfNeededByUser:user type:ZMUpdateEventTypeConversationAssetAdd data:payload];
 }
 
 @end

--- a/Source/Conversations/MockTransportSessionConversationsTests.m
+++ b/Source/Conversations/MockTransportSessionConversationsTests.m
@@ -523,7 +523,7 @@
     XCTAssertEqual(response.HTTPStatus, 201);
     MockEvent *lastEvent = conversation.events.lastObject;
     XCTAssertNotNil(lastEvent);
-    XCTAssertEqual(lastEvent.eventType, ZMTUpdateEventConversationOTRMessageAdd);
+    XCTAssertEqual(lastEvent.eventType, ZMUpdateEventTypeConversationOtrMessageAdd);
     XCTAssertNotNil(lastEvent.decryptedOTRData);
     ZMGenericMessage *decryptedMessage = (ZMGenericMessage *)[[[[ZMGenericMessageBuilder alloc] init] mergeFromData:lastEvent.decryptedOTRData] build];
     XCTAssertEqualObjects(decryptedMessage.text.content, messageText);

--- a/Source/MockTransportSession+internal.h
+++ b/Source/MockTransportSession+internal.h
@@ -33,7 +33,7 @@
 - (MockConnection *)fetchConnectionFrom:(MockUser *)userID to:(MockUser *)otherUserID;
 - (void)addPushToken:(NSDictionary *)pushToken;
 - (ZMTransportResponse *)errorResponseWithCode:(NSInteger)code reason:(NSString *)reason;
-- (MockEvent *)eventIfNeededByUser:(MockUser *)byUser type:(ZMTUpdateEventType)type data:(id<ZMTransportData>)data;
+- (MockEvent *)eventIfNeededByUser:(MockUser *)byUser type:(ZMUpdateEventType)type data:(id<ZMTransportData>)data;
 
 - (MockConnection *)connectionFromUserIdentifier:(NSString *)fromUserIdentifier toUserIdentifier:(NSString *)toUserIdentifier;
 

--- a/Source/MockTransportSessionPushChannelTests.m
+++ b/Source/MockTransportSessionPushChannelTests.m
@@ -492,8 +492,11 @@
     [self.sut sendIsTypingEventForConversation:conversation user:user2 started:YES];
     WaitForAllGroupsToBeEmpty(0.5);
     
+    XCTAssert([self waitWithTimeout:0.5 verificationBlock:^BOOL{
+        return 1 == self.pushChannelReceivedEvents.count;
+    }]);
+    
     // THEN
-    XCTAssertEqual(self.pushChannelReceivedEvents.count, 1u);
     TestPushChannelEvent *isTypingEvent = self.pushChannelReceivedEvents.firstObject;
     
     XCTAssertEqual(isTypingEvent.type, ZMUpdateEventTypeConversationTyping);

--- a/Source/MockTransportSessionPushChannelTests.m
+++ b/Source/MockTransportSessionPushChannelTests.m
@@ -158,7 +158,7 @@
     
     XCTAssertEqual(self.pushChannelReceivedEvents.count, 1u);
     TestPushChannelEvent *nameEvent = self.pushChannelReceivedEvents.firstObject;
-    XCTAssertEqual(nameEvent.type, ZMTUpdateEventUserUpdate);
+    XCTAssertEqual(nameEvent.type, ZMUpdateEventTypeUserUpdate);
     XCTAssertEqualObjects(nameEvent.payload.asDictionary[@"user"], expectedUserPayload);
 }
 
@@ -195,7 +195,7 @@
     
     XCTAssertEqual(self.pushChannelReceivedEvents.count, 1u);
     TestPushChannelEvent *nameEvent = self.pushChannelReceivedEvents.firstObject;
-    XCTAssertEqual(nameEvent.type, ZMTUpdateEventUserUpdate);
+    XCTAssertEqual(nameEvent.type, ZMUpdateEventTypeUserUpdate);
     XCTAssertEqualObjects(nameEvent.payload.asDictionary[@"user"], expectedUserPayload);
 }
 
@@ -230,7 +230,7 @@
     
     XCTAssertEqual(self.pushChannelReceivedEvents.count, 1u);
     TestPushChannelEvent *nameEvent = self.pushChannelReceivedEvents.firstObject;
-    XCTAssertEqual(nameEvent.type, ZMTUpdateEventUserUpdate);
+    XCTAssertEqual(nameEvent.type, ZMUpdateEventTypeUserUpdate);
     XCTAssertEqualObjects(nameEvent.payload.asDictionary[@"user"], expectedUserPayload);
 }
 
@@ -262,7 +262,7 @@
     
     XCTAssertEqual(self.pushChannelReceivedEvents.count, 1u);
     TestPushChannelEvent *connectEvent = self.pushChannelReceivedEvents.firstObject;
-    XCTAssertEqual(connectEvent.type, ZMTUpdateEventUserConnection);
+    XCTAssertEqual(connectEvent.type, ZMUpdateEventTypeUserConnection);
     XCTAssertEqualObjects(connectEvent.payload.asDictionary[@"connection"], expectedConnectionPayload);
 }
 
@@ -293,7 +293,7 @@
     
     XCTAssertEqual(self.pushChannelReceivedEvents.count, 1u);
     TestPushChannelEvent *connectEvent = self.pushChannelReceivedEvents.firstObject;
-    XCTAssertEqual(connectEvent.type, ZMTUpdateEventUserConnection);
+    XCTAssertEqual(connectEvent.type, ZMUpdateEventTypeUserConnection);
     XCTAssertEqualObjects(connectEvent.payload.asDictionary[@"connection"], expectedConnectionPayload);
 }
 
@@ -327,17 +327,17 @@
     // THEN
     XCTAssertEqual(self.pushChannelReceivedEvents.count, 4u);
     TestPushChannelEvent *createConversationEvent = [self popEventMatchingWithBlock:^BOOL(TestPushChannelEvent *event) {
-        return event.type == ZMTUpdateEventConversationCreate;
+        return event.type == ZMUpdateEventTypeConversationCreate;
     }];
     TestPushChannelEvent *memberJoinEvent = [self popEventMatchingWithBlock:^BOOL(TestPushChannelEvent *event) {
-        return event.type == ZMTUpdateEventConversationMemberJoin;
+        return event.type == ZMUpdateEventTypeConversationMemberJoin;
     }];
     TestPushChannelEvent *textEvent1 = [self popEventMatchingWithBlock:^BOOL(TestPushChannelEvent *event) {
-        return ((event.type == ZMTUpdateEventConversationOTRMessageAdd) &&
+        return ((event.type == ZMUpdateEventTypeConversationOtrMessageAdd) &&
                 [event.payload.asDictionary[@"data"] isEqual:event1Payload]);
     }];
     TestPushChannelEvent *textEvent2 = [self popEventMatchingWithBlock:^BOOL(TestPushChannelEvent *event) {
-        return ((event.type == ZMTUpdateEventConversationOTRMessageAdd) &&
+        return ((event.type == ZMUpdateEventTypeConversationOtrMessageAdd) &&
                 [event.payload.asDictionary[@"data"] isEqual:event2Payload]);
     }];
     XCTAssertNotNil(createConversationEvent);
@@ -375,7 +375,7 @@
     XCTAssertEqual(self.pushChannelReceivedEvents.count, 1u);
     TestPushChannelEvent *nameChangeName = self.pushChannelReceivedEvents.firstObject;
     
-    XCTAssertEqual(nameChangeName.type, ZMTUpdateEventConversationRename);
+    XCTAssertEqual(nameChangeName.type, ZMUpdateEventTypeConversationRename);
 }
 
 - (void)testThatWeReceiveAPushEventWhenCreatingAConversation
@@ -401,7 +401,7 @@
     // THEN
     XCTAssertGreaterThanOrEqual(self.pushChannelReceivedEvents.count, 1u);
     NSUInteger index = [self.pushChannelReceivedEvents indexOfObjectPassingTest:^BOOL(TestPushChannelEvent *event, NSUInteger idx ZM_UNUSED, BOOL *stop ZM_UNUSED) {
-        return event.type == ZMTUpdateEventConversationCreate;
+        return event.type == ZMUpdateEventTypeConversationCreate;
     }];
     XCTAssertTrue(index != NSNotFound);
     if(index != NSNotFound) {
@@ -438,7 +438,7 @@
     XCTAssertEqual(self.pushChannelReceivedEvents.count, 1u);
     TestPushChannelEvent *memberAddEvent = self.pushChannelReceivedEvents.firstObject;
     
-    XCTAssertEqual(memberAddEvent.type, ZMTUpdateEventConversationMemberJoin);
+    XCTAssertEqual(memberAddEvent.type, ZMUpdateEventTypeConversationMemberJoin);
 }
 
 - (void)testThatWeReceiveAPushEventWhenRemovingAParticipantFromAConversation
@@ -466,7 +466,7 @@
     // THEN
     XCTAssertEqual(self.pushChannelReceivedEvents.count, 1u);
     TestPushChannelEvent *memberRemoveEvent = self.pushChannelReceivedEvents.firstObject;
-    XCTAssertEqual(memberRemoveEvent.type, ZMTUpdateEventConversationMemberLeave);
+    XCTAssertEqual(memberRemoveEvent.type, ZMUpdateEventTypeConversationMemberLeave);
 }
 
 - (void)testThatWeReceiveIsTypingPushEvents;
@@ -496,7 +496,7 @@
     XCTAssertEqual(self.pushChannelReceivedEvents.count, 1u);
     TestPushChannelEvent *isTypingEvent = self.pushChannelReceivedEvents.firstObject;
     
-    XCTAssertEqual(isTypingEvent.type, ZMTUpdateEventConversationTyping);
+    XCTAssertEqual(isTypingEvent.type, ZMUpdateEventTypeConversationTyping);
     NSDictionary *expected = @{@"conversation": conversationIdentifier,
                                @"from": userIdentifier,
                                @"data": @{@"status": @"started"},

--- a/Source/MockTransportSessionTests.m
+++ b/Source/MockTransportSessionTests.m
@@ -33,7 +33,7 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransportTests";
 @property (nonatomic) id<ZMTransportData> payload;
 @property (nonatomic) NSUUID *uuid;
 @property (nonatomic) BOOL isTransient;
-@property (nonatomic) ZMTUpdateEventType type;
+@property (nonatomic) ZMUpdateEventType type;
 
 @end
 
@@ -48,7 +48,7 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransportTests";
         self.isTransient = transient;
         self.type = [MockEvent typeFromString:payload[@"type"]];
         
-        if(self.type == ZMTUpdateEventUnknown) {
+        if(self.type == ZMUpdateEventTypeUnknown) {
             ZMLogError(@"Unknown event type in event: %@", payload);
             return nil;
         }
@@ -56,7 +56,7 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransportTests";
     return self;
 }
 
-- (ZMTUpdateEventType)type
+- (ZMUpdateEventType)type
 {
     return [MockEvent typeFromString:[[self.payload asDictionary] stringForKey:@"type"]];
 }

--- a/Source/Push Events/MockEvent.h
+++ b/Source/Push Events/MockEvent.h
@@ -24,49 +24,6 @@
 @protocol ZMTransportData;
 @class MockUser;
 
-typedef NS_ENUM(NSUInteger, ZMTUpdateEventType) {
-    ZMTUpdateEventUnknown = 0,
-    ZMTUpdateEventCallCandidatesAdd,
-    ZMTUpdateEventCallCandidatesUpdate,
-    ZMTUpdateEventCallDeviceInfo,
-    ZMTUpdateEventCallFlowActive,
-    ZMTUpdateEventCallFlowAdd,
-    ZMTUpdateEventCallFlowDelete,
-    ZMTUpdateEventCallState,
-    ZMTUpdateEventCallParticipants,
-    ZMTUpdateEventCallRemoteSDP,
-    ZMTUpdateEventConversationAssetAdd,
-    ZMTUpdateEventConversationConnectRequest,
-    ZMTUpdateEventConversationCreate,
-    ZMTUpdateEventConversationHotKnock,
-    ZMTUpdateEventConversationKnock,
-    ZMTUpdateEventConversationMemberJoin,
-    ZMTUpdateEventConversationMemberLeave,
-    ZMTUpdateEventConversationMemberUpdate,
-    ZMTUpdateEventConversationMessageAdd,
-    ZMTUpdateEventConversationClientMessageAdd,
-    ZMTUpdateEventConversationOTRMessageAdd,
-    ZMTUpdateEventConversationOTRAssetAdd,
-    ZMTUpdateEventConversationRename,
-    ZMTUpdateEventConversationTyping,
-    ZMTUpdateEventConversationVoiceChannel,
-    ZMTUpdateEventConversationVoiceChannelActivate,
-    ZMTUpdateEventConversationVoiceChannelDeactivate,
-    ZMTUpdateEventUserConnection,
-    ZMTUpdateEventUserNew,
-    ZMTUpdateEventUserUpdate,
-    ZMTUpdateEventUserPushRemove,
-    ZMTUPdateEventUserClientAdd,
-    ZMTUpdateEventUserClientRemove,
-    ZMTUpdateEventTeamCreate,
-    ZMTUpdateEventTeamUpdate,
-    ZMTUpdateEventTeamDelete,
-    ZMTUpdateEventTeamMemberJoin,
-    ZMTUpdateEventTeamMemberLeave,
-    ZMTUpdateEventTeamConversationCreate,
-    ZMTUpdateEventTeamConversationDelete
-};
-
 
 @interface MockEvent : NSManagedObject
 
@@ -74,15 +31,15 @@ typedef NS_ENUM(NSUInteger, ZMTUpdateEventType) {
 @property (nonatomic, nonnull) NSString *identifier;
 @property (nonatomic, nullable) NSDate *time;
 @property (nonatomic, nonnull) NSString *type;
-@property (nonatomic, readonly) ZMTUpdateEventType eventType;
+@property (nonatomic, readonly) ZMUpdateEventType eventType;
 @property (nonatomic, nullable) id data;
 @property (nonatomic, nullable) NSData* decryptedOTRData;
 @property (nonatomic, nullable) MockConversation *conversation;
 
 - (nonnull id<ZMTransportData>)transportData;
 
-+ (nullable NSString *)stringFromType:(ZMTUpdateEventType)status;
-+ (ZMTUpdateEventType)typeFromString:(nonnull NSString *)string;
++ (nullable NSString *)stringFromType:(ZMUpdateEventType)type;
++ (ZMUpdateEventType)typeFromString:(nonnull NSString *)string;
 
 // Event considered persistent on the backend should receive an identifier
 + (nonnull NSArray *)persistentEvents;

--- a/Source/Push Events/MockEvent.m
+++ b/Source/Push Events/MockEvent.m
@@ -37,92 +37,29 @@ static ZMLogLevel_t const ZMLogLevel ZM_UNUSED = ZMLogLevelWarn;
 @dynamic conversation;
 @dynamic decryptedOTRData;
 
-+ (NSArray *)eventStringToEnumValueTuples
+
++ (NSString *)stringFromType:(ZMUpdateEventType)type
 {
-    static NSArray *mapping;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        mapping =
-        @[
-          @[@(ZMTUpdateEventCallDeviceInfo),@"call.device-info"],
-          @[@(ZMTUpdateEventCallFlowActive),@"call.flow-active"],
-          @[@(ZMTUpdateEventCallFlowAdd),@"call.flow-add"],
-          @[@(ZMTUpdateEventCallFlowDelete),@"call.flow-delete"],
-          @[@(ZMTUpdateEventCallParticipants),@"call.participants"],
-          @[@(ZMTUpdateEventCallCandidatesAdd),@"call.remote-candidates-add"],
-          @[@(ZMTUpdateEventCallCandidatesUpdate),@"call.remote-candidates-update"],
-          @[@(ZMTUpdateEventCallRemoteSDP),@"call.remote-sdp"],
-          @[@(ZMTUpdateEventCallState),@"call.state"],
-          @[@(ZMTUpdateEventConversationAssetAdd),@"conversation.asset-add"],
-          @[@(ZMTUpdateEventConversationConnectRequest),@"conversation.connect-request"],
-          @[@(ZMTUpdateEventConversationCreate),@"conversation.create"],
-          @[@(ZMTUpdateEventConversationHotKnock),@"conversation.hot-knock"],
-          @[@(ZMTUpdateEventConversationKnock),@"conversation.knock"],
-          @[@(ZMTUpdateEventConversationMemberJoin),@"conversation.member-join"],
-          @[@(ZMTUpdateEventConversationMemberLeave),@"conversation.member-leave"],
-          @[@(ZMTUpdateEventConversationMemberUpdate),@"conversation.member-update"],
-          @[@(ZMTUpdateEventConversationMessageAdd),@"conversation.message-add"],
-          @[@(ZMTUpdateEventConversationClientMessageAdd),@"conversation.client-message-add"],
-          @[@(ZMTUpdateEventConversationOTRMessageAdd),@"conversation.otr-message-add"],
-          @[@(ZMTUpdateEventConversationOTRAssetAdd),@"conversation.otr-asset-add"],
-          @[@(ZMTUpdateEventConversationRename),@"conversation.rename"],
-          @[@(ZMTUpdateEventConversationTyping),@"conversation.typing"],
-          @[@(ZMTUpdateEventConversationVoiceChannel),@"conversation.voice-channel"],
-          @[@(ZMTUpdateEventConversationVoiceChannelActivate),@"conversation.voice-channel-activate"],
-          @[@(ZMTUpdateEventConversationVoiceChannelDeactivate),@"conversation.voice-channel-deactivate"],
-          @[@(ZMTUpdateEventUserConnection),@"user.connection"],
-          @[@(ZMTUpdateEventUserNew),@"user.new"],
-          @[@(ZMTUpdateEventUserPushRemove),@"user.push-remove"],
-          @[@(ZMTUpdateEventUserUpdate),@"user.update"],
-          @[@(ZMTUPdateEventUserClientAdd),@"user.client-add"],
-          @[@(ZMTUpdateEventUserClientRemove),@"user.client-remove"],
-          @[@(ZMTUpdateEventTeamCreate),@"team.create"],
-          @[@(ZMTUpdateEventTeamUpdate),@"team.update"],
-          @[@(ZMTUpdateEventTeamDelete),@"team.delete"],
-          @[@(ZMTUpdateEventTeamMemberJoin),@"team.member-join"],
-          @[@(ZMTUpdateEventTeamMemberLeave),@"team.member-leave"],
-          @[@(ZMTUpdateEventTeamConversationCreate),@"team.conversation-create"],
-          @[@(ZMTUpdateEventTeamConversationDelete),@"team.conversation-delete"]
-          ];
-    });
-    return mapping;
+    return [ZMUpdateEvent eventTypeStringForUpdateEventType:type];
 }
 
-+ (NSString *)stringFromType:(ZMTUpdateEventType)type
++ (ZMUpdateEventType)typeFromString:(NSString *)string
 {
-    for(NSArray *tuple in [MockEvent eventStringToEnumValueTuples]) {
-        if([tuple[0] isEqualToNumber:@(type)]) {
-            return tuple[1];
-        }
-    }
-    RequireString(false, "Failed to parse ZMTUpdateEventType %lu", (unsigned long)type);
-}
-
-+ (ZMTUpdateEventType)typeFromString:(NSString *)string
-{
-    for(NSArray *tuple in [MockEvent eventStringToEnumValueTuples]) {
-        if([tuple[1] isEqualToString:string]) {
-            return (ZMTUpdateEventType) ((NSNumber *)tuple[0]).intValue;
-        }
-    }
-    RequireString(false, "Failed to parse ZMTConnectionStatus %s", string.UTF8String);
+    return [ZMUpdateEvent updateEventTypeForEventTypeString:string];
 }
 
 + (NSArray *)persistentEvents;
 {
-   return @[@(ZMTUpdateEventConversationRename),
-            @(ZMTUpdateEventConversationMemberJoin),
-            @(ZMTUpdateEventConversationMemberLeave),
-            @(ZMTUpdateEventConversationConnectRequest),
-            @(ZMTUpdateEventConversationMessageAdd),
-            @(ZMTUpdateEventConversationClientMessageAdd),
-            @(ZMTUpdateEventConversationAssetAdd),
-            @(ZMTUpdateEventConversationKnock),
-            @(ZMTUpdateEventConversationHotKnock),
-            @(ZMTUpdateEventConversationVoiceChannelActivate),
-            @(ZMTUpdateEventConversationVoiceChannelDeactivate),
-            @(ZMTUpdateEventConversationOTRMessageAdd),
-            @(ZMTUpdateEventConversationOTRAssetAdd)
+    return @[@(ZMUpdateEventTypeConversationRename),
+             @(ZMUpdateEventTypeConversationMemberJoin),
+             @(ZMUpdateEventTypeConversationMemberLeave),
+             @(ZMUpdateEventTypeConversationConnectRequest),
+             @(ZMUpdateEventTypeConversationMessageAdd),
+             @(ZMUpdateEventTypeConversationClientMessageAdd),
+             @(ZMUpdateEventTypeConversationAssetAdd),
+             @(ZMUpdateEventTypeConversationKnock),
+             @(ZMUpdateEventTypeConversationOtrMessageAdd),
+             @(ZMUpdateEventTypeConversationOtrAssetAdd)
             ];
 }
 
@@ -138,9 +75,9 @@ static ZMLogLevel_t const ZMLogLevel ZM_UNUSED = ZMLogLevelWarn;
             };
 }
 
-- (ZMTUpdateEventType)eventType
+- (ZMUpdateEventType)eventType
 {
-    return [[self class] typeFromString:self.type];
+    return (ZMUpdateEventType)[[self class] typeFromString:self.type];
 }
 
 @end

--- a/Source/Push Events/MockTransportSessionTeamEventsTests.swift
+++ b/Source/Push Events/MockTransportSessionTeamEventsTests.swift
@@ -22,14 +22,15 @@ import XCTest
 
 class MockTransportSessionTeamEventsTests : MockTransportSessionTests {
     
-    func check(event: TestPushChannelEvent?, hasType type: ZMTUpdateEventType, team: MockTeam, data: [String : String] = [:], file: StaticString = #file, line: UInt = #line) {
+    func check(event: TestPushChannelEvent?, hasType type: ZMUpdateEventType, team: MockTeam, data: [String : String] = [:], file: StaticString = #file, line: UInt = #line) {
         check(event: event, hasType: type, teamIdentifier: team.identifier, data: data, file: file, line: line)
     }
     
-    func check(event: TestPushChannelEvent?, hasType type: ZMTUpdateEventType, teamIdentifier: String, data: [String : String?] = [:], file: StaticString = #file, line: UInt = #line) {
+    func check(event: TestPushChannelEvent?, hasType type: ZMUpdateEventType, teamIdentifier: String, data: [String : String?] = [:], file: StaticString = #file, line: UInt = #line) {
         guard let event = event else { XCTFail("Should have event", file: file, line: line); return }
         
-        XCTAssertEqual(event.type, type, "Wrong type", file: file, line: line)
+        
+        XCTAssertEqual(event.type, type, "Wrong type \(String(describing: ZMUpdateEvent.eventTypeString(for: type)))", file: file, line: line)
         
         guard let payload = event.payload as? [String : Any] else { XCTFail("Event should have payload", file: file, line: line); return }
         
@@ -78,7 +79,7 @@ extension MockTransportSessionTeamEventsTests {
         let events = pushChannelReceivedEvents as! [TestPushChannelEvent]
         XCTAssertEqual(events.count, 1)
         
-        check(event: events.first, hasType: .ZMTUpdateEventTeamDelete, teamIdentifier: teamIdentifier)
+        check(event: events.first, hasType: .teamDelete, teamIdentifier: teamIdentifier)
     }
     
     func testThatItCreatesEventsForUpdatedTeams() {
@@ -112,7 +113,7 @@ extension MockTransportSessionTeamEventsTests {
             "icon" : assetId,
             "icon_key" : assetKey
         ]
-        check(event: events.first, hasType: .ZMTUpdateEventTeamUpdate, team: team, data: updateData)
+        check(event: events.first, hasType: .teamUpdate, team: team, data: updateData)
     }
     
     func testThatItCreatesEventsForUpdatedTeamsAndHasOnlyChangedData() {
@@ -142,7 +143,7 @@ extension MockTransportSessionTeamEventsTests {
         let updateData = [
             "name" : newName,
         ]
-        check(event: events.first, hasType: .ZMTUpdateEventTeamUpdate, team: team, data: updateData)
+        check(event: events.first, hasType: .teamUpdate, team: team, data: updateData)
     }
 
 }
@@ -176,7 +177,7 @@ extension MockTransportSessionTeamEventsTests {
         let updateData = [
             "user" : newUser.identifier,
             ]
-        check(event: events.first, hasType: .ZMTUpdateEventTeamMemberJoin, team: team, data: updateData)
+        check(event: events.first, hasType: .teamMemberJoin, team: team, data: updateData)
     }
     
     func testThatItCreatesEventWhenMemberIsRemovedFromTeam() {
@@ -206,7 +207,7 @@ extension MockTransportSessionTeamEventsTests {
         let updateData = [
             "user" : user.identifier,
             ]
-        check(event: events.first, hasType: .ZMTUpdateEventTeamMemberLeave, team: team, data: updateData)
+        check(event: events.first, hasType: .teamMemberLeave, team: team, data: updateData)
     }
     
     func testThatItCreatesEventWhenSelfMemberIsRemovedFromTeam() {
@@ -234,7 +235,7 @@ extension MockTransportSessionTeamEventsTests {
         let updateData = [
             "user" : selfUser.identifier,
             ]
-        check(event: events.first, hasType: .ZMTUpdateEventTeamMemberLeave, team: team, data: updateData)
+        check(event: events.first, hasType: .teamMemberLeave, team: team, data: updateData)
     }
 }
 
@@ -268,7 +269,7 @@ extension MockTransportSessionTeamEventsTests {
         let updateData = [
             "conv" : conversation.identifier,
             ]
-        check(event: events.first, hasType: .ZMTUpdateEventTeamConversationCreate, team: team, data: updateData)
+        check(event: events.first, hasType: .teamConversationCreate, team: team, data: updateData)
     }
 
     func testThatItCreatesEventWhenConversationIsDeletedInTeam() {
@@ -302,7 +303,7 @@ extension MockTransportSessionTeamEventsTests {
         let updateData = [
             "conv" : conversationIdentifier!,
             ]
-        check(event: events.first, hasType: .ZMTUpdateEventTeamConversationDelete, team: team, data: updateData)
+        check(event: events.first, hasType: .teamConversationDelete, team: team, data: updateData)
     }
     
     func testThatItDoesNotSendEventsFromATeamThatYouAreNotAMemberOf() {

--- a/Tests/MockTransportSessionTests.h
+++ b/Tests/MockTransportSessionTests.h
@@ -29,7 +29,7 @@
 
 @interface TestPushChannelEvent : NSObject
 
-@property (nonatomic, readonly) ZMTUpdateEventType type;
+@property (nonatomic, readonly) ZMUpdateEventType type;
 @property (nonatomic, readonly) id<ZMTransportData> payload;
 @property (nonatomic, readonly) NSUUID *uuid;
 @property (nonatomic, readonly) BOOL isTransient;


### PR DESCRIPTION
## What's new in this PR?

* `wire-ios-mocktransport` depends on `wire-ios-transport` and we can reuse the update event constants defined there.