### PR TITLE
Updated GET /push/tokens response format

### DIFF
--- a/Source/Push Token/MockTransportPushTokenTests.swift
+++ b/Source/Push Token/MockTransportPushTokenTests.swift
@@ -79,9 +79,10 @@ class MockTransportPushTokenTests_Swift: MockTransportSessionTests {
 
         // then
         XCTAssertEqual(result?.httpStatus, 200)
-        guard let payload = result?.payload?.asArray() as? [NSDictionary] else { return XCTFail() }
+        guard let payload = result?.payload?.asDictionary() as? [String : NSArray] else { XCTFail(); return }
         XCTAssertFalse(payload.isEmpty)
-        XCTAssertTrue(payload.contains(payload1))
-        XCTAssertTrue(payload.contains(payload2))
+        guard let results = payload["tokens"] else { XCTFail(); return }
+        XCTAssertTrue(results.contains(payload1))
+        XCTAssertTrue(results.contains(payload2))
     }
 }

--- a/Source/Push Token/MockTransportSession+PushToken.swift
+++ b/Source/Push Token/MockTransportSession+PushToken.swift
@@ -35,7 +35,10 @@ extension MockTransportSession {
     }
 
     func processGetPushTokens() -> ZMTransportResponse {
-        return ZMTransportResponse(payload: Array(pushTokens.values) as NSArray, httpStatus: 200, transportSessionError: nil)
+        let payload = [
+            "tokens" : Array(pushTokens.values)
+        ] as NSDictionary
+        return ZMTransportResponse(payload: payload, httpStatus: 200, transportSessionError: nil)
     }
 
     func processDeletePushToken(_ token: String?) -> ZMTransportResponse {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Backend API was tweaked and it now returns a dictionary with results instead of an array of tokens.
