### PR TITLE
Enable CoreData threading violation flag

### DIFF
--- a/Source/MockTransportSession.m
+++ b/Source/MockTransportSession.m
@@ -242,7 +242,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
     __unused id store = [psc addPersistentStoreWithType:NSInMemoryStoreType configuration:nil URL:nil options:nil error:nil];
     NSAssert(store != nil, @"");
     
-    self.managedObjectContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
+    self.managedObjectContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
     [self.managedObjectContext createDispatchGroups];
     [self.managedObjectContext addGroup:group];
     self.managedObjectContext.persistentStoreCoordinator = psc;    

--- a/Source/MockTransportSessionRequestsTests.m
+++ b/Source/MockTransportSessionRequestsTests.m
@@ -368,7 +368,8 @@
     // WHEN
     [self.sut resetReceivedRequests];
     [self sendRequestToMockTransportSession:req3];
-    
+    WaitForAllGroupsToBeEmpty(0.5);
+
     // THEN
     XCTAssertEqualObjects(self.sut.receivedRequests, @[req3]);
 }

--- a/WireMockTransport.xcodeproj/xcshareddata/xcschemes/WireMockTransport.xcscheme
+++ b/WireMockTransport.xcodeproj/xcshareddata/xcschemes/WireMockTransport.xcscheme
@@ -40,9 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -71,7 +70,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -87,6 +85,12 @@
             ReferencedContainer = "container:WireMockTransport.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.ConcurrencyDebug 1"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>


### PR DESCRIPTION
## What's new in this PR?

### Issues

To make sure tests are reliable it's best for CoreData to assert when managed object is used from the wrong thread

### Solutions

MockTransport has one NSManagedObjectContext that is initialized with it's own private queue. There seems to be no difference if it's set to use main queue. This then solves all the possible multithreading issues and tests pass (almost) without changes.