### PR TITLE
Moved services fetching to teams endpoint

### DIFF
--- a/Source/MockTransportSession.m
+++ b/Source/MockTransportSession.m
@@ -437,7 +437,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
              @[@"/invitations", @"processInvitationsRequest:"],
              @[@"/teams", @"processTeamsRequest:"],
              @[@"/broadcast", @"processBroadcastRequest:"],
-             @[@"/services", @"processServicesSearchRequest:"],
              @[@"/providers", @"processServicesProvidersRequest:"]
              ];
 }

--- a/Source/Services/MockServicesTests.swift
+++ b/Source/Services/MockServicesTests.swift
@@ -22,12 +22,13 @@ import Foundation
 class MockServicesTests: MockTransportSessionTests {
     func testThatInsertedServiceCanBeQueried() {
         // given
+        let teamID = UUID()
         let service1 = sut.insertService(name: "Normal Service", identifier: UUID().transportString(), provider: UUID().transportString())
         let _ = sut.insertService(name: "Other Service", identifier: UUID().transportString(), provider: UUID().transportString())
 
         // when
 
-        let response = sut.processServicesSearchRequest(ZMTransportRequest(path: "/services?tags=tutorial&start=Normal", method: .methodGET, payload: nil))
+        let response = sut.processTeamsRequest(ZMTransportRequest(path: "/teams/\(teamID.transportString())/services/whitelisted?prefix=Normal", method: .methodGET, payload: nil))
         // then
         XCTAssertEqual(response.httpStatus, 200)
         XCTAssertNotNil(response.payload?.asDictionary()?["services"])

--- a/Source/Services/MockTransportSession+Services.swift
+++ b/Source/Services/MockTransportSession+Services.swift
@@ -19,17 +19,15 @@
 import Foundation
 
 extension MockTransportSession {
-    @objc(processServicesSearchRequest:)
-    public func processServicesSearchRequest(_ request: ZMTransportRequest) -> ZMTransportResponse {
-        guard let _ = request.queryParameters["tags"] as? String,
-                let startsWith = request.queryParameters["start"] as? String else {
-                    return ZMTransportResponse(payload: nil, httpStatus: 400, transportSessionError: nil)
+
+    func fetchWhitelistedServicesForTeam(with identifier: String?, query: [String : Any]) -> ZMTransportResponse? {
+        var predicate: NSPredicate? = nil
+        if let prefix = query["prefix"] as? String {
+            predicate = NSPredicate(format: "%K beginswith[c] %@", #keyPath(MockService.name), prefix)
         }
-        
-        let predicate = NSPredicate(format: "%K beginswith[c] %@", #keyPath(MockService.name), startsWith)
-        
+
         let services: [MockService] = MockService.fetchAll(in: managedObjectContext, withPredicate: predicate)
-        
+
         let payload: [String : Any] = [
             "services" : services.map { $0.payload },
             "has_more" : false

--- a/Source/Teams/MockTransportSession+teams.swift
+++ b/Source/Teams/MockTransportSession+teams.swift
@@ -34,6 +34,8 @@ extension MockTransportSession {
             response = fetchAllTeams(query: request.queryParameters)
         case "/teams/*":
             response = fetchTeam(with: request.RESTComponents(index: 1))
+        case "/teams/*/services/whitelisted":
+            response = fetchWhitelistedServicesForTeam(with: request.RESTComponents(index: 1), query: request.queryParameters)
         case "/teams/*/invitations":
             response = sendTeamInvitation(with: request.RESTComponents(index: 1))
         case "/teams/*/members":


### PR DESCRIPTION
## What's new in this PR?

### Issues

The endpoint to fetch services was moved under `/teams`. 