### PR TITLE
Added otr_muted_status to conversation

### DIFF
--- a/Resources/MockTransportSession.xcdatamodeld/TestTransportSession.xcdatamodel/contents
+++ b/Resources/MockTransportSession.xcdatamodeld/TestTransportSession.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="13241" systemVersion="17D102" minimumToolsVersion="Xcode 4.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14315.18" systemVersion="17G65" minimumToolsVersion="Xcode 4.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Asset" representedClassName="MockAsset" syncable="YES">
         <attribute name="contentType" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="conversation" optional="YES" attributeType="String" syncable="YES"/>
@@ -26,6 +26,7 @@
         <attribute name="otrArchivedRef" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="otrMuted" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="otrMutedRef" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="otrMutedStatus" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="selfIdentifier" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="type" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <relationship name="activeUsers" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="User" inverseName="activeConversations" inverseEntity="User" syncable="YES"/>
@@ -139,7 +140,7 @@
     <elements>
         <element name="Asset" positionX="0" positionY="0" width="128" height="135"/>
         <element name="Connection" positionX="0" positionY="0" width="128" height="135"/>
-        <element name="Conversation" positionX="0" positionY="0" width="128" height="285"/>
+        <element name="Conversation" positionX="0" positionY="0" width="128" height="300"/>
         <element name="Event" positionX="0" positionY="0" width="128" height="150"/>
         <element name="Member" positionX="18" positionY="162" width="128" height="90"/>
         <element name="PersonalInvitation" positionX="0" positionY="0" width="128" height="135"/>

--- a/Source/Conversations/MockConversation.h
+++ b/Source/Conversations/MockConversation.h
@@ -38,6 +38,7 @@ typedef NS_ENUM(int16_t, ZMTConversationType) {
 
 @property (nonatomic, nullable) NSString *otrArchivedRef;
 @property (nonatomic, nullable) NSString *otrMutedRef;
+@property (nonatomic, nullable) NSNumber *otrMutedStatus;
 @property (nonatomic) BOOL otrArchived;
 @property (nonatomic) BOOL otrMuted;
 

--- a/Source/Conversations/MockConversation.m
+++ b/Source/Conversations/MockConversation.m
@@ -47,6 +47,7 @@
 @dynamic otrArchivedRef;
 @dynamic otrMuted;
 @dynamic otrMutedRef;
+@dynamic otrMutedStatus;
 @dynamic team;
 @dynamic accessRole;
 @dynamic accessMode;
@@ -192,6 +193,7 @@
     selfInfo[@"id"] = self.selfIdentifier;
     selfInfo[@"otr_muted_ref"] = self.otrMutedRef ?: [NSNull null];
     selfInfo[@"otr_muted"] = @(self.otrMuted);
+    selfInfo[@"otr_muted_status"] = self.otrMutedStatus ?: [NSNull null];
     selfInfo[@"otr_archived_ref"] = self.otrArchivedRef ?: [NSNull null];
     selfInfo[@"otr_archived"] = @(self.otrArchived);
     

--- a/Source/Conversations/MockTransportSession+conversations.m
+++ b/Source/Conversations/MockTransportSession+conversations.m
@@ -236,6 +236,13 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransport";
     return archivedRef != nil;
 }
 
+- (BOOL)updateConversation:(MockConversation *)conversation isOTRMutedStatusFromPutSelfConversationPayload:(NSDictionary *)payload
+{
+    NSNumber *mutedStatus = [payload optionalNumberForKey:@"otr_muted_status"];
+    conversation.otrMutedStatus = mutedStatus;
+    return mutedStatus != nil;
+}
+
 - (ZMTransportResponse *)processPutConversationSelf:(NSString *)conversationId payload:(NSDictionary *)payload;
 {
     MockConversation *conversation = [self conversationByIdentifier:conversationId];
@@ -245,8 +252,9 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransport";
     
     BOOL hadOTRMuted = [self updateConversation:conversation isOTRMutedFromPutSelfConversationPayload:payload];
     BOOL hadOTRArchived = [self updateConversation:conversation isOTRArchivedFromPutSelfConversationPayload:payload];
+    BOOL hadOTRMutedStatus = [self updateConversation:conversation isOTRMutedStatusFromPutSelfConversationPayload:payload];
 
-    if( !hadOTRArchived && !hadOTRMuted) {
+    if( !hadOTRArchived && !hadOTRMuted && !hadOTRMutedStatus) {
         return [ZMTransportResponse responseWithPayload:@{@"error":@"no useful payload"} HTTPStatus:400 transportSessionError:nil];
     }
     

--- a/Source/MockTransportSessionTests.m
+++ b/Source/MockTransportSessionTests.m
@@ -494,7 +494,7 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransportTests";
         
         NSDictionary *selfMember = members[@"self"];
         XCTAssertTrue([selfMember isKindOfClass:[NSDictionary class]]);
-        keys = @[@"id", @"otr_muted", @"otr_muted_ref", @"otr_archived", @"otr_archived_ref"];
+        keys = @[@"id", @"otr_muted", @"otr_muted_ref", @"otr_muted_status", @"otr_archived", @"otr_archived_ref"];
         AssertDictionaryHasKeys(selfMember, keys);
         
         XCTAssertEqualObjects(selfMember[@"otr_muted"], @(conversation.otrMuted));


### PR DESCRIPTION
## What's new in this PR?

### Issues

We need mock backend support for 3-way mute setting. The value is stored as an opaque integer and no convenience methods are added for accessing the state because it's up to the clients to decide how to treat it.
