### PR TITLE
Return 204 if the updated value is already set

### DIFF
--- a/Source/Conversations/MockTransportSession+conversations.swift
+++ b/Source/Conversations/MockTransportSession+conversations.swift
@@ -36,6 +36,9 @@ extension MockTransportSession {
         guard let receiptMode = payload["receipt_mode"] as? Int else {
             return ZMTransportResponse(payload: nil, httpStatus: 400, transportSessionError: nil)
         }
+        guard receiptMode != conversation.receiptMode?.intValue else {
+            return ZMTransportResponse(payload: nil, httpStatus: 204, transportSessionError: nil)
+        }
         
         conversation.receiptMode = NSNumber(value: receiptMode)
         


### PR DESCRIPTION
## What's new in this PR?

Match the BE behaviour by returning 204 on a request to update receipt mode to the existing value.
