### PR TITLE
Add support for specifying the device class of a client

### DIFF
--- a/Source/Broadcast/MockTransportSessionBroadcastTests.swift
+++ b/Source/Broadcast/MockTransportSessionBroadcastTests.swift
@@ -42,13 +42,13 @@ class MockTransportSessionBroadcastTests: MockTransportSessionTests {
         
         sut.performRemoteChanges { session in
             selfUser = session.insertSelfUser(withName: "foo")
-            selfClient = session.registerClient(for: selfUser, label: "self user", type: "permanent")
-            secondSelfClient = session.registerClient(for: selfUser, label: "self2", type: "permanent")
+            selfClient = session.registerClient(for: selfUser, label: "self user", type: "permanent", deviceClass: "phone")
+            secondSelfClient = session.registerClient(for: selfUser, label: "self2", type: "permanent", deviceClass: "phone")
             
             otherUser = session.insertUser(withName: "bar")
             otherUserClient = otherUser.clients.anyObject() as? MockUserClient
-            secondOtherUserClient = session.registerClient(for: otherUser, label: "other2", type: "permanent")
-            otherUserRedundantClient = session.registerClient(for: otherUser, label: "other redundant", type: "permanent")
+            secondOtherUserClient = session.registerClient(for: otherUser, label: "other2", type: "permanent", deviceClass: "phone")
+            otherUserRedundantClient = session.registerClient(for: otherUser, label: "other redundant", type: "permanent", deviceClass: "phone")
             
             let connection = session.insertConnection(withSelfUser: selfUser, to: otherUser)
             connection.status = "accepted"
@@ -104,7 +104,7 @@ class MockTransportSessionBroadcastTests: MockTransportSessionTests {
 
         sut.performRemoteChanges { session in
             selfUser = session.insertSelfUser(withName: "Self User")
-            selfClient = session.registerClient(for: selfUser, label: "self user", type: "permanent")
+            selfClient = session.registerClient(for: selfUser, label: "self user", type: "permanent", deviceClass: "phone")
 
             otherUser = session.insertUser(withName: "Team member1")
             otherUserClient = otherUser.clients.anyObject() as? MockUserClient
@@ -153,7 +153,7 @@ class MockTransportSessionBroadcastTests: MockTransportSessionTests {
 
         sut.performRemoteChanges { session in
             selfUser = session.insertSelfUser(withName: "Self User")
-            selfClient = session.registerClient(for: selfUser, label: "self user", type: "permanent")
+            selfClient = session.registerClient(for: selfUser, label: "self user", type: "permanent", deviceClass: "phone")
 
             otherUser = session.insertUser(withName: "Team member1")
             otherUserClient = otherUser.clients.anyObject() as? MockUserClient
@@ -203,7 +203,7 @@ class MockTransportSessionBroadcastTests: MockTransportSessionTests {
 
         sut.performRemoteChanges { session in
             selfUser = session.insertSelfUser(withName: "Self User")
-            selfClient = session.registerClient(for: selfUser, label: "self user", type: "permanent")
+            selfClient = session.registerClient(for: selfUser, label: "self user", type: "permanent", deviceClass: "phone")
 
             otherUser = session.insertUser(withName: "Team member1")
             otherUserClient = otherUser.clients.anyObject() as? MockUserClient

--- a/Source/Clients and OTR/MockTransportSessionClientsTests.m
+++ b/Source/Clients and OTR/MockTransportSessionClientsTests.m
@@ -406,7 +406,7 @@
     __block MockUserClient *client;
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
         selfUser = [session insertSelfUserWithName:@"Foo"];
-        client = [session registerClientForUser:selfUser label:@"client" type:@"permanent"];
+        client = [session registerClientForUser:selfUser label:@"client" type:@"permanent" deviceClass:@"phone"];
         client.deviceClass = @"desktop";
         client.time = [NSDate dateWithTimeIntervalSince1970:10000];
         client.model = @"iPod Touch";
@@ -414,7 +414,7 @@
         client.locationLongitude = -10;
         client.address = @"10.0.0.2";
         
-        [session registerClientForUser:selfUser label:@"foobar" type:@"temporary"];
+        [session registerClientForUser:selfUser label:@"foobar" type:@"temporary" deviceClass:@"desktop"];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     
@@ -448,7 +448,7 @@
     __block MockUser *user1;
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
         user1 = [session insertUserWithName:@"Foo"];
-        [session registerClientForUser:user1 label:@"foobar" type:@"temporary"];
+        [session registerClientForUser:user1 label:@"foobar" type:@"temporary" deviceClass:@"desktop"];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     
@@ -484,10 +484,10 @@
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
         selfUser = [session insertSelfUserWithName:@"Foo"];
         
-        [session registerClientForUser:selfUser label:@"foobar" type:@"temporary"];
-        [session registerClientForUser:selfUser label:@"324211xx" type:@"permanent"];
+        [session registerClientForUser:selfUser label:@"foobar" type:@"temporary" deviceClass:@"phone"];
+        [session registerClientForUser:selfUser label:@"324211xx" type:@"permanent" deviceClass:@"phone"];
         
-        client = [session registerClientForUser:selfUser label:@"client" type:@"permanent"];
+        client = [session registerClientForUser:selfUser label:@"client" type:@"permanent" deviceClass:@"phone"];
         client.deviceClass = @"desktop";
         client.time = [NSDate dateWithTimeIntervalSince1970:10000];
         client.model = @"iPod Touch";
@@ -495,7 +495,7 @@
         client.locationLongitude = -10;
         client.address = @"10.0.0.2";
         
-        [session registerClientForUser:selfUser label:@"XXXXX" type:@"permanent"];
+        [session registerClientForUser:selfUser label:@"XXXXX" type:@"permanent" deviceClass:@"phone"];
 
     }];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -528,7 +528,7 @@
     __block MockUserClient *client;
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
         selfUser = [session insertSelfUserWithName:@"Foo"];
-        client = [session registerClientForUser:selfUser label:@"client" type:@"permanent"];
+        client = [session registerClientForUser:selfUser label:@"client" type:@"permanent" deviceClass:@"phone"];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     
@@ -568,7 +568,7 @@
     
     // WHEN
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
-        client = [session registerClientForUser:selfUser label:@"client" type:@"permanent"];
+        client = [session registerClientForUser:selfUser label:@"client" type:@"permanent" deviceClass:@"phone"];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     
@@ -606,7 +606,7 @@
     __block MockUserClient *client;
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
         selfUser = [session insertSelfUserWithName:@"Foo"];
-        [session registerClientForUser:selfUser label:@"self user" type:@"permanent"];
+        [session registerClientForUser:selfUser label:@"self user" type:@"permanent" deviceClass:@"phone"];
         client = [selfUser.clients anyObject];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -638,6 +638,7 @@
     __block MockUserClient *client;
     NSString *clientLabel = @"client label";
     NSString *clientType = @"permanent";
+    NSString *deviceClass = @"phone";
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
         selfUser = [session insertSelfUserWithName:@"Foo"];
     }];
@@ -645,7 +646,7 @@
     
     // WHEN
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
-        client = [session registerClientForUser:selfUser label:clientLabel type:clientType];
+        client = [session registerClientForUser:selfUser label:clientLabel type:clientType  deviceClass:deviceClass];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     
@@ -662,7 +663,8 @@
                                                       },
                                               @"time": client.time.transportString,
                                               @"id" : client.identifier,
-                                              @"type" : clientType
+                                              @"type" : clientType,
+                                              @"class" : deviceClass
                                       },
                                       @"type" : @"user.client-add"
     };
@@ -679,7 +681,7 @@
     
     // WHEN
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
-        [session registerClientForUser:otherUser label:@"client" type:@"permanent"];
+        [session registerClientForUser:otherUser label:@"client" type:@"permanent" deviceClass:@"phone"];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     
@@ -693,7 +695,7 @@
     __block MockUserClient *client;
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
         otherUser = [session insertUserWithName:@"Foo"];
-        client = [session registerClientForUser:otherUser label:@"client" type:@"permanent"];
+        client = [session registerClientForUser:otherUser label:@"client" type:@"permanent" deviceClass:@"phone"];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     
@@ -714,8 +716,8 @@
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
         
         MockUser *selfUser = [session insertSelfUserWithName:@"Brigite Sorço"];
-        selfClient = [session registerClientForUser:selfUser label:@"moi" type:@"permanent"];
-        destClient = [session registerClientForUser:selfUser label:@"autre" type:@"permanent"];
+        selfClient = [session registerClientForUser:selfUser label:@"moi" type:@"permanent" deviceClass:@"phone"];
+        destClient = [session registerClientForUser:selfUser label:@"autre" type:@"permanent" deviceClass:@"phone"];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     

--- a/Source/Clients and OTR/MockUserClient.swift
+++ b/Source/Clients and OTR/MockUserClient.swift
@@ -135,15 +135,16 @@ extension MockUserClient {
     }
     
     /// Insert a new client, automatically generate prekeys and last key
-    @objc(insertClientWithLabel:type:user:context:)
-    public static func insertClient(label: String, type: String, for user: MockUser, in context: NSManagedObjectContext) -> MockUserClient?
+    @objc(insertClientWithLabel:type:deviceClass:user:context:)
+    public static func insertClient(label: String, type: String = "permanent", deviceClass: String = "phone", for user: MockUser, in context: NSManagedObjectContext) -> MockUserClient?
     {
         let newClient = NSEntityDescription.insertNewObject(forEntityName: "UserClient", into: context) as! MockUserClient
     
         newClient.user = user
         newClient.identifier = NSString.createAlphanumerical() as String
         newClient.label = label;
-        newClient.type = type;
+        newClient.type = type
+        newClient.deviceClass = deviceClass
         newClient.time = Date()
 
         var generatedPrekeys : [[String: Any]]?

--- a/Source/Conversations/MockTransportSessionConversationsTests.m
+++ b/Source/Conversations/MockTransportSessionConversationsTests.m
@@ -243,15 +243,15 @@
     
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
         selfUser = [session insertSelfUserWithName:@"foo"];
-        [session registerClientForUser:selfUser label:@"self user" type:@"permanent"];
+        [session registerClientForUser:selfUser label:@"self user" type:@"permanent" deviceClass:@"phone"];
         otherUser = [session insertUserWithName:@"bar"];
         conversation = [session insertConversationWithCreator:selfUser otherUsers:@[otherUser] type:ZMTConversationTypeOneOnOne];
         
         selfClient = [selfUser.clients anyObject];
-        secondSelfClient = [session registerClientForUser:selfUser label:@"self2" type:@"permanent"];
+        secondSelfClient = [session registerClientForUser:selfUser label:@"self2" type:@"permanent" deviceClass:@"phone"];
         
         otherUserClient = [otherUser.clients anyObject];
-        secondOtherUserClient = [session registerClientForUser:otherUser label:@"other2" type:@"permanent"];
+        secondOtherUserClient = [session registerClientForUser:otherUser label:@"other2" type:@"permanent" deviceClass:@"phone"];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     NSUInteger previousNotificationsCount = self.sut.generatedPushEvents.count;
@@ -312,16 +312,16 @@
     
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
         selfUser = [session insertSelfUserWithName:@"foo"];
-        [session registerClientForUser:selfUser label:@"self user" type:@"permanent"];
+        [session registerClientForUser:selfUser label:@"self user" type:@"permanent" deviceClass:@"phone"];
         otherUser = [session insertUserWithName:@"bar"];
         MockUser *extraUser = [session insertUserWithName:@"bar"];
         conversation = [session insertConversationWithCreator:selfUser otherUsers:@[otherUser, extraUser] type:ZMTConversationTypeOneOnOne];
         
         selfClient = [selfUser.clients anyObject];
-        secondSelfClient = [session registerClientForUser:selfUser label:@"self2" type:@"permanent"];
+        secondSelfClient = [session registerClientForUser:selfUser label:@"self2" type:@"permanent" deviceClass:@"phone"];
         
         otherUserClient1 = [otherUser.clients anyObject];
-        otherUserClient2 = [session registerClientForUser:otherUser label:@"other2" type:@"permanent"];
+        otherUserClient2 = [session registerClientForUser:otherUser label:@"other2" type:@"permanent" deviceClass:@"phone"];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     NSUInteger previousNotificationsCount = self.sut.generatedPushEvents.count;
@@ -375,13 +375,13 @@
     
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
         selfUser = [session insertSelfUserWithName:@"foo"];
-        [session registerClientForUser:selfUser label:@"self user" type:@"permanent"];
+        [session registerClientForUser:selfUser label:@"self user" type:@"permanent" deviceClass:@"phone"];
         otherUser = [session insertUserWithName:@"bar"];
         MockUser *extraUser = [session insertUserWithName:@"bar"];
         conversation = [session insertConversationWithCreator:selfUser otherUsers:@[otherUser, extraUser] type:ZMTConversationTypeOneOnOne];
         
         selfClient = [selfUser.clients anyObject];
-        secondSelfClient = [session registerClientForUser:selfUser label:@"self2" type:@"permanent"];
+        secondSelfClient = [session registerClientForUser:selfUser label:@"self2" type:@"permanent" deviceClass:@"phone"];
         
         otherUserClient = [otherUser.clients anyObject];
     }];
@@ -430,15 +430,15 @@
     
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
         selfUser = [session insertSelfUserWithName:@"foo"];
-        [session registerClientForUser:selfUser label:@"self user" type:@"permanent"];
+        [session registerClientForUser:selfUser label:@"self user" type:@"permanent" deviceClass:@"phone"];
 
         otherUser = [session insertUserWithName:@"bar"];
         otherUserClient = [otherUser.clients anyObject];
-        secondOtherUserClient = [session registerClientForUser:otherUser label:@"other2" type:@"permanent"];
-        redundantClient = [session registerClientForUser:otherUser label:@"Wire for OS/2" type:@"permanent"];
+        secondOtherUserClient = [session registerClientForUser:otherUser label:@"other2" type:@"permanent" deviceClass:@"phone"];
+        redundantClient = [session registerClientForUser:otherUser label:@"Wire for OS/2" type:@"permanent" deviceClass:@"phone"];
         
         selfClient = [selfUser.clients anyObject];
-        secondSelfClient = [session registerClientForUser:selfUser label:@"self2" type:@"permanent"];
+        secondSelfClient = [session registerClientForUser:selfUser label:@"self2" type:@"permanent" deviceClass:@"phone"];
         
         conversation = [session insertConversationWithCreator:selfUser otherUsers:@[otherUser] type:ZMTConversationTypeOneOnOne];
     }];
@@ -493,7 +493,7 @@
     
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
         selfUser = [session insertSelfUserWithName:@"foo"];
-        [session registerClientForUser:selfUser label:@"self user" type:@"permanent"];
+        [session registerClientForUser:selfUser label:@"self user" type:@"permanent" deviceClass:@"phone"];
         
         otherUser = [session insertUserWithName:@"bar"];
         conversation = [session insertConversationWithCreator:selfUser otherUsers:@[otherUser] type:ZMTConversationTypeOneOnOne];
@@ -544,16 +544,16 @@
     
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
         selfUser = [session insertSelfUserWithName:@"foo"];
-        [session registerClientForUser:selfUser label:@"self user" type:@"permanent"];
+        [session registerClientForUser:selfUser label:@"self user" type:@"permanent" deviceClass:@"phone"];
 
         otherUser = [session insertUserWithName:@"bar"];
         conversation = [session insertConversationWithCreator:selfUser otherUsers:@[otherUser] type:ZMTConversationTypeOneOnOne];
         
         selfClient = [selfUser.clients anyObject];
-        secondSelfClient = [session registerClientForUser:selfUser label:@"self2" type:@"permanent"];
+        secondSelfClient = [session registerClientForUser:selfUser label:@"self2" type:@"permanent" deviceClass:@"phone"];
         
         otherUserClient = [otherUser.clients anyObject];
-        secondOtherUserClient = [session registerClientForUser:otherUser label:@"other2" type:@"permanent"];
+        secondOtherUserClient = [session registerClientForUser:otherUser label:@"other2" type:@"permanent" deviceClass:@"phone"];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     NSUInteger previousNotificationsCount = self.sut.generatedPushEvents.count;
@@ -623,16 +623,16 @@
     
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
         selfUser = [session insertSelfUserWithName:@"foo"];
-        [session registerClientForUser:selfUser label:@"self user" type:@"permanent"];
+        [session registerClientForUser:selfUser label:@"self user" type:@"permanent" deviceClass:@"phone"];
 
         otherUser = [session insertUserWithName:@"bar"];
         conversation = [session insertConversationWithCreator:selfUser otherUsers:@[otherUser] type:ZMTConversationTypeOneOnOne];
         
         selfClient = [selfUser.clients anyObject];
-        secondSelfClient = [session registerClientForUser:selfUser label:@"self2" type:@"permanent"];
+        secondSelfClient = [session registerClientForUser:selfUser label:@"self2" type:@"permanent" deviceClass:@"phone"];
         
         otherUserClient = [otherUser.clients anyObject];
-        secondOtherUserClient = [session registerClientForUser:otherUser label:@"other2" type:@"permanent"];
+        secondOtherUserClient = [session registerClientForUser:otherUser label:@"other2" type:@"permanent" deviceClass:@"phone"];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     NSUInteger previousNotificationsCount = self.sut.generatedPushEvents.count;
@@ -685,7 +685,7 @@
     
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
         selfUser = [session insertSelfUserWithName:@"foo"];
-        [session registerClientForUser:selfUser label:@"self user" type:@"permanent"];
+        [session registerClientForUser:selfUser label:@"self user" type:@"permanent" deviceClass:@"phone"];
         otherUser = [session insertUserWithName:@"bar"];
         conversation = [session insertConversationWithCreator:selfUser otherUsers:@[otherUser] type:ZMTConversationTypeOneOnOne];
         
@@ -727,7 +727,7 @@
     
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
         selfUser = [session insertSelfUserWithName:@"foo"];
-        [session registerClientForUser:selfUser label:@"self user" type:@"permanent"];
+        [session registerClientForUser:selfUser label:@"self user" type:@"permanent" deviceClass:@"phone"];
         otherUser = [session insertUserWithName:@"bar"];
         conversation = [session insertConversationWithCreator:selfUser otherUsers:@[otherUser] type:ZMTConversationTypeOneOnOne];
         
@@ -769,7 +769,7 @@
     
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
         selfUser = [session insertSelfUserWithName:@"Me Myself"];
-        [session registerClientForUser:selfUser label:@"Self Client" type:@"permanent"];
+        [session registerClientForUser:selfUser label:@"Self Client" type:@"permanent" deviceClass:@"phone"];
         conversation = [session insertSelfConversationWithSelfUser:selfUser];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -828,8 +828,8 @@
     __block NSMutableDictionary *expectedPayloadData = [@{@"text": [data base64EncodedStringWithOptions:0]} mutableCopy];
     
     [self testThatInsertingArbitraryEventWithBlock:^MockEvent *(id<MockTransportSessionObjectCreation> session, MockConversation *conversation) {
-        MockUserClient *client1 = [session registerClientForUser:self.sut.selfUser label:@"client1" type:@"permanent"];
-        MockUserClient *client2 = [session registerClientForUser:self.sut.selfUser label:@"client2" type:@"permanent"];
+        MockUserClient *client1 = [session registerClientForUser:self.sut.selfUser label:@"client1" type:@"permanent" deviceClass:@"phone"];
+        MockUserClient *client2 = [session registerClientForUser:self.sut.selfUser label:@"client2" type:@"permanent" deviceClass:@"phone"];
         expectedPayloadData[@"sender"] = client1.identifier;
         expectedPayloadData[@"recipient"] = client2.identifier;
         return [conversation insertOTRMessageFromClient:client1 toClient:client2 data:data];
@@ -847,8 +847,8 @@
                                                           @"id": assetId.transportString} mutableCopy];
     
     [self testThatInsertingArbitraryEventWithBlock:^MockEvent *(id<MockTransportSessionObjectCreation> session, MockConversation *conversation) {
-        MockUserClient *client1 = [session registerClientForUser:self.sut.selfUser label:@"client1" type:@"permanent"];
-        MockUserClient *client2 = [session registerClientForUser:self.sut.selfUser label:@"client2" type:@"permanent"];
+        MockUserClient *client1 = [session registerClientForUser:self.sut.selfUser label:@"client1" type:@"permanent" deviceClass:@"phone"];
+        MockUserClient *client2 = [session registerClientForUser:self.sut.selfUser label:@"client2" type:@"permanent" deviceClass:@"phone"];
         expectedPayloadData[@"sender"] = client1.identifier;
         expectedPayloadData[@"recipient"] = client2.identifier;
         
@@ -868,7 +868,7 @@
     
     [self testThatInsertingArbitraryEventWithBlock:^MockEvent *(id<MockTransportSessionObjectCreation> session, MockConversation *conversation) {
         MockUserClient *client1 = [self.sut.selfUser.clients anyObject];
-        MockUserClient *client2 = [session registerClientForUser:self.sut.selfUser label:@"client2" type:@"permanent"];
+        MockUserClient *client2 = [session registerClientForUser:self.sut.selfUser label:@"client2" type:@"permanent" deviceClass:@"phone"];
         expectedPayloadData[@"sender"] = client1.identifier;
         expectedPayloadData[@"recipient"] = client2.identifier;
         

--- a/Source/MockTransportSession.h
+++ b/Source/MockTransportSession.h
@@ -155,6 +155,7 @@ typedef ZMTransportResponse * _Nullable (^ZMCustomResponseGeneratorBlock)(ZMTran
 
 - (MockConnection *)createConnectionRequestFromUser:(MockUser*)fromUser toUser:(MockUser*)toUser message:(nullable NSString *)message;
 
+- (MockUserClient *)registerClientForUser:(MockUser *)user;
 - (MockUserClient *)registerClientForUser:(MockUser *)user label:(NSString *)label type:(NSString *)type deviceClass:(NSString *)deviceClass;
 
 /// deletes a remote user client for a user

--- a/Source/MockTransportSession.h
+++ b/Source/MockTransportSession.h
@@ -155,7 +155,7 @@ typedef ZMTransportResponse * _Nullable (^ZMCustomResponseGeneratorBlock)(ZMTran
 
 - (MockConnection *)createConnectionRequestFromUser:(MockUser*)fromUser toUser:(MockUser*)toUser message:(nullable NSString *)message;
 
-- (MockUserClient *)registerClientForUser:(MockUser *)user label:(NSString *)label type:(NSString *)type;
+- (MockUserClient *)registerClientForUser:(MockUser *)user label:(NSString *)label type:(NSString *)type deviceClass:(NSString *)deviceClass;
 
 /// deletes a remote user client for a user
 - (void)deleteUserClientWithIdentifier:(NSString *)identifier forUser:(MockUser *)user;

--- a/Source/MockTransportSession.m
+++ b/Source/MockTransportSession.m
@@ -620,7 +620,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
     
     if (shouldIncludeClient) {
         
-        MockUserClient *client = [MockUserClient insertClientWithLabel:user.identifier type:@"permanent" user:user context:self.managedObjectContext];
+        MockUserClient *client = [MockUserClient insertClientWithLabel:user.identifier type:@"permanent" deviceClass:@"phone" user:user context:self.managedObjectContext];
         
         NSMutableSet *clients = [NSMutableSet setWithObject:client];
         user.clients = clients;
@@ -803,9 +803,9 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
     
 }
 
-- (MockUserClient *)registerClientForUser:(MockUser *)user label:(NSString *)label type:(NSString *)type
+- (MockUserClient *)registerClientForUser:(MockUser *)user label:(NSString *)label type:(NSString *)type deviceClass:(NSString *)deviceClass
 {
-    MockUserClient *client = [MockUserClient insertClientWithLabel:label type:type user:user context:self.managedObjectContext];
+    MockUserClient *client = [MockUserClient insertClientWithLabel:label type:type deviceClass:deviceClass user:user context:self.managedObjectContext];
     return client;
 }
 

--- a/Source/MockTransportSession.m
+++ b/Source/MockTransportSession.m
@@ -803,6 +803,11 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
     
 }
 
+- (MockUserClient *)registerClientForUser:(MockUser *)user
+{
+    return [self registerClientForUser:user label:@"Mock Phone" type:@"permanent" deviceClass:@"phone"];
+}
+
 - (MockUserClient *)registerClientForUser:(MockUser *)user label:(NSString *)label type:(NSString *)type deviceClass:(NSString *)deviceClass
 {
     MockUserClient *client = [MockUserClient insertClientWithLabel:label type:type deviceClass:deviceClass user:user context:self.managedObjectContext];

--- a/Source/MockTransportSessionObjectCreationTests.swift
+++ b/Source/MockTransportSessionObjectCreationTests.swift
@@ -62,7 +62,7 @@ class MockTransportSessionObjectCreationTests : MockTransportSessionTests {
         var user: MockUser!
         self.sut.performRemoteChanges { (session) in
             user = session.insertUser(withName: "Foo")
-            session.registerClient(for: user, label: "iPhone 89", type: "permanent")
+            session.registerClient(for: user, label: "iPhone 89", type: "permanent", deviceClass: "phone")
         }
         
         // WHEN
@@ -81,7 +81,7 @@ class MockTransportSessionObjectCreationTests : MockTransportSessionTests {
         var identifier: String!
         self.sut.performRemoteChanges { (session) in
             user = session.insertUser(withName: "Foo")
-            let client = session.registerClient(for: user, label: "iPhone 89", type: "permanent")
+            let client = session.registerClient(for: user, label: "iPhone 89", type: "permanent", deviceClass: "phone")
             identifier = client.identifier
         }
         

--- a/Source/Users/MockTransportSessionUsersTests.m
+++ b/Source/Users/MockTransportSessionUsersTests.m
@@ -825,9 +825,9 @@
         selfUser = [session insertSelfUserWithName:@"foo"];
         otherUser = [session insertUserWithName:@"bar"];
         thirdUser = [session insertUserWithName:@"foobar"];
-        selfClient = [session registerClientForUser:selfUser label:@"self1" type:@"permanent"];
-        otherUserClient = [session registerClientForUser:otherUser label:@"other1" type:@"permanent"];
-        secondOtherUserClient = [session registerClientForUser:otherUser label:@"other2" type:@"permanent"];
+        selfClient = [session registerClientForUser:selfUser label:@"self1" type:@"permanent" deviceClass:@"phone"];
+        otherUserClient = [session registerClientForUser:otherUser label:@"other1" type:@"permanent" deviceClass:@"phone"];
+        secondOtherUserClient = [session registerClientForUser:otherUser label:@"other2" type:@"permanent" deviceClass:@"phone"];
     }];
     
     NSString *redunduntClientId = [NSString createAlphanumericalString];


### PR DESCRIPTION
## What's new in this PR?

- Add support for specifying the device class of client when registering it
- Add support for /users/<userId>/clients/<clientId> endpoint.