### PR TITLE
Deleted clients where falsely reported as redundant

### DIFF
--- a/Source/Broadcast/MockTransportSession+Broadcast.m
+++ b/Source/Broadcast/MockTransportSession+Broadcast.m
@@ -54,9 +54,9 @@
     
     NSString *onlyForUser = query[@"report_missing"];
     NSDictionary *missedClients = [self missedClients:recipients sender:senderClient onlyForUserId:onlyForUser];
-    NSDictionary *redundantClients = [self redundantClients:recipients];
+    NSDictionary *deletedClients = [self deletedClients:recipients];
     
-    NSDictionary *responsePayload = @{@"missing": missedClients, @"redundant": redundantClients, @"time": [NSDate date].transportString};
+    NSDictionary *responsePayload = @{@"missing": missedClients, @"deleted": deletedClients, @"time": [NSDate date].transportString};
     
     NSInteger statusCode = 412;
     if (missedClients.count == 0) {
@@ -83,9 +83,9 @@
     
     NSString *onlyForUser = query[@"report_missing"];
     NSDictionary *missedClients = [self missedClientsFromRecipients:otrMetaData.recipients sender:senderClient onlyForUserId:onlyForUser];
-    NSDictionary *redundantClients = [self redundantClientsFromRecipients:otrMetaData.recipients];
+    NSDictionary *deletedClients = [self deletedClientsFromRecipients:otrMetaData.recipients];
     
-    NSDictionary *payload = @{@"missing": missedClients, @"redundant": redundantClients, @"time": [NSDate date].transportString};
+    NSDictionary *payload = @{@"missing": missedClients, @"deleted": deletedClients, @"time": [NSDate date].transportString};
     
     NSInteger statusCode = 412;
     if (missedClients.count == 0) {

--- a/Source/Broadcast/MockTransportSessionBroadcastTests.swift
+++ b/Source/Broadcast/MockTransportSessionBroadcastTests.swift
@@ -23,10 +23,10 @@ class MockTransportSessionBroadcastTests: MockTransportSessionTests {
     
     func assertExpectedPayload(_ payload : [String : Any], in response:  ZMTransportResponse, file: StaticString = #file, line: UInt = #line) {
         let missing = response.payload!.asDictionary()!["missing"] as! [String : Any]
-        let redundant = response.payload!.asDictionary()!["redundant"] as! [String : Any]
+        let deleted = response.payload!.asDictionary()!["deleted"] as! [String : Any]
         
         XCTAssertTrue(NSDictionary(dictionary: missing).isEqual(to: payload["missing"]! as! [String : Any]), "missing clients: \n\(missing)\n doesn't match expected payload:\n \(payload)", file: file, line: line)
-        XCTAssertTrue(NSDictionary(dictionary: redundant).isEqual(to: payload["redundant"]! as! [String : Any]), "redundant clients: \n\(redundant)\n doesn't match expected payload:\n \(payload)", file: file, line: line)
+        XCTAssertTrue(NSDictionary(dictionary: deleted).isEqual(to: payload["deleted"]! as! [String : Any]), "deleted clients: \n\(deleted)\n doesn't match expected payload:\n \(payload)", file: file, line: line)
     }
     
     func testThatItReturnsMissingConnectedUsersWhenReceivingOTRMessage() {
@@ -84,9 +84,8 @@ class MockTransportSessionBroadcastTests: MockTransportSessionTests {
                 XCTAssertEqual(response.httpStatus, 412)
                 
                 let expectedPayload = [
-                    "missing"  : [ selfUser.identifier  : [secondSelfClient.identifier!],
-                                   otherUser.identifier : [secondOtherUserClient.identifier!] ],
-                    "redundant" : [ otherUser.identifier : [otherUserRedundantClient.identifier!]]
+                    "missing" : [ selfUser.identifier  : [secondSelfClient.identifier!], otherUser.identifier : [secondOtherUserClient.identifier!] ],
+                    "deleted" : [ otherUser.identifier : [otherUserRedundantClient.identifier!]]
                 ]
                 
                 assertExpectedPayload(expectedPayload, in: response)
@@ -135,7 +134,7 @@ class MockTransportSessionBroadcastTests: MockTransportSessionTests {
 
                 let expectedPayload = [
                     "missing"  : [ otherUser.identifier : [otherUserClient.identifier!] ],
-                    "redundant" : [:]
+                    "deleted" : [:]
                 ]
 
                 assertExpectedPayload(expectedPayload, in: response)
@@ -185,7 +184,7 @@ class MockTransportSessionBroadcastTests: MockTransportSessionTests {
 
                 let expectedPayload = [
                     "missing"  : [:],
-                    "redundant" : [:]
+                    "deleted" : [:]
                 ]
 
                 assertExpectedPayload(expectedPayload, in: response)
@@ -235,7 +234,7 @@ class MockTransportSessionBroadcastTests: MockTransportSessionTests {
 
                 let expectedPayload = [
                     "missing"  : [:],
-                    "redundant" : [:]
+                    "deleted" : [:]
                 ]
 
                 assertExpectedPayload(expectedPayload, in: response)

--- a/Source/Clients and OTR/MockTransportSession+OTR.h
+++ b/Source/Clients and OTR/MockTransportSession+OTR.h
@@ -44,11 +44,11 @@
 
 /// Returns a list of redundant clients in the conversation that were included in the list of intendend recipients
 /// @param recipients list of intender recipients
-- (NSDictionary *)redundantClients:(NSDictionary *)recipients conversation:(MockConversation *)conversation;
+- (NSDictionary *)deletedClients:(NSDictionary *)recipients conversation:(MockConversation *)conversation;
 
 /// Returns a list of redundant clients for broascasting that were included in the list of intendend recipients
 /// @param recipients list of intender recipients
-- (NSDictionary *)redundantClients:(NSDictionary *)recipients;
+- (NSDictionary *)deletedClients:(NSDictionary *)recipients;
 
 - (MockUserClient *)otrMessageSenderFromClientId:(ZMClientId *)sender;
 
@@ -62,13 +62,13 @@
 /// @param onlyForUserId if not nil, only return missing recipients matching this user ID
 - (NSDictionary *)missedClientsFromRecipients:(NSArray *)recipients sender:(MockUserClient *)sender onlyForUserId:(NSString *)onlyForUserId;
 
-/// Returns a list of redundant clients in the conversation that were included in the list of intendend recipients
+/// Returns a list of deleted clients in the conversation that were included in the list of intendend recipients
 /// @param recipients list of intender recipients
-- (NSDictionary *)redundantClientsFromRecipients:(NSArray *)recipients conversation:(MockConversation *)conversation;
+- (NSDictionary *)deletedClientsFromRecipients:(NSArray *)recipients conversation:(MockConversation *)conversation;
 
-/// Returns a list of redundant clients for broascasting that were included in the list of intendend recipients
+/// Returns a list of deleted clients for broascasting that were included in the list of intendend recipients
 /// @param recipients list of intender recipients
-- (NSDictionary *)redundantClientsFromRecipients:(NSArray *)recipients;
+- (NSDictionary *)deletedClientsFromRecipients:(NSArray *)recipients;
 
 
 - (void)insertOTRMessageEventsToConversation:(MockConversation *)conversation

--- a/Source/Clients and OTR/MockTransportSession+OTR.m
+++ b/Source/Clients and OTR/MockTransportSession+OTR.m
@@ -66,19 +66,19 @@
     return missedClients;
 }
 
-- (NSDictionary *)redundantClients:(NSDictionary *)recipients conversation:(MockConversation *)conversation
+- (NSDictionary *)deletedClients:(NSDictionary *)recipients conversation:(MockConversation *)conversation
 {
-    return [self redundantClients:recipients users:conversation.activeUsers.set];
+    return [self deletedClients:recipients users:conversation.activeUsers.set];
 }
 
-- (NSDictionary *)redundantClients:(NSDictionary *)recipients
+- (NSDictionary *)deletedClients:(NSDictionary *)recipients
 {
-    return [self redundantClients:recipients users:self.selfUser.connectionsAndTeamMembers];
+    return [self deletedClients:recipients users:self.selfUser.connectionsAndTeamMembers];
 }
 
-- (NSDictionary *)redundantClients:(NSDictionary *)recipients users:(NSSet<MockUser *> *)users
+- (NSDictionary *)deletedClients:(NSDictionary *)recipients users:(NSSet<MockUser *> *)users
 {
-    NSMutableDictionary *redundantClients = [NSMutableDictionary new];
+    NSMutableDictionary *deletedClients = [NSMutableDictionary new];
     for (NSString *userId in recipients) {
         NSDictionary *recipientPayload = recipients[userId];
         MockUser *user = [users filteredSetUsingPredicate:[NSPredicate predicateWithFormat:@"identifier == %@", userId]].anyObject;
@@ -86,13 +86,13 @@
         NSSet *userClients = [user.clients mapWithBlock:^id(MockUserClient *client) {
             return client.identifier;
         }];
-        NSMutableSet *redundantUserClients = [NSMutableSet setWithArray:recipientClients];
-        [redundantUserClients minusSet:userClients];
-        if (redundantUserClients.count > 0) {
-            redundantClients[userId] = redundantUserClients.allObjects;
+        NSMutableSet *deletedUserClients = [NSMutableSet setWithArray:recipientClients];
+        [deletedUserClients minusSet:userClients];
+        if (deletedUserClients.count > 0) {
+            deletedClients[userId] = deletedUserClients.allObjects;
         }
     }
-    return redundantClients;
+    return deletedClients;
 }
 
 - (MockUserClient *)otrMessageSenderFromClientId:(ZMClientId *)sender
@@ -148,19 +148,19 @@
     return missedClients;
 }
 
-- (NSDictionary *)redundantClientsFromRecipients:(NSArray *)recipients conversation:(MockConversation *)conversation
+- (NSDictionary *)deletedClientsFromRecipients:(NSArray *)recipients conversation:(MockConversation *)conversation
 {
-    return [self redundantClientsFromRecipients:recipients users:conversation.activeUsers.set];
+    return [self deletedClientsFromRecipients:recipients users:conversation.activeUsers.set];
 }
 
-- (NSDictionary *)redundantClientsFromRecipients:(NSArray *)recipients
+- (NSDictionary *)deletedClientsFromRecipients:(NSArray *)recipients
 {
-    return [self redundantClientsFromRecipients:recipients users:self.selfUser.connectionsAndTeamMembers];
+    return [self deletedClientsFromRecipients:recipients users:self.selfUser.connectionsAndTeamMembers];
 }
 
-- (NSDictionary *)redundantClientsFromRecipients:(NSArray *)recipients users:(NSSet<MockUser *> *)users
+- (NSDictionary *)deletedClientsFromRecipients:(NSArray *)recipients users:(NSSet<MockUser *> *)users
 {
-    NSMutableDictionary *redundantClients = [NSMutableDictionary new];
+    NSMutableDictionary *deletedClients = [NSMutableDictionary new];
     
     for (MockUser *user in users) {
         ZMUserEntry *userEntry = [[recipients filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(ZMUserEntry  * _Nonnull evaluatedObject, NSDictionary<NSString *,id> * _Nullable __unused bindings) {
@@ -177,13 +177,15 @@
             return client.identifier;
         }];
         
-        NSMutableSet *redundantUserClients = [NSMutableSet setWithArray:recipientClients];
-        [redundantUserClients minusSet:userClients];
-        if (redundantUserClients.count > 0) {
-            redundantClients[user.identifier] = redundantUserClients.allObjects;
+        NSMutableSet *deletedUserClients = [NSMutableSet setWithArray:recipientClients];
+        [deletedUserClients minusSet:userClients];
+        
+        if (deletedUserClients.count > 0) {
+            deletedClients[user.identifier] = deletedUserClients.allObjects;
         }
     }
-    return redundantClients;
+    
+    return deletedClients;
 }
 
 - (void)insertOTRMessageEventsToConversation:(MockConversation *)conversation

--- a/Source/Conversations/MockTransportSession+conversations.m
+++ b/Source/Conversations/MockTransportSession+conversations.m
@@ -137,9 +137,9 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransport";
 
     NSString *onlyForUser = query[@"report_missing"];
     NSDictionary *missedClients = [self missedClients:recipients conversation:conversation sender:senderClient onlyForUserId:onlyForUser];
-    NSDictionary *redundantClients = [self redundantClients:recipients conversation:conversation];
+    NSDictionary *deletedClients = [self deletedClients:recipients conversation:conversation];
     
-    NSDictionary *responsePayload = @{@"missing": missedClients, @"redundant": redundantClients, @"time": [NSDate date].transportString};
+    NSDictionary *responsePayload = @{@"missing": missedClients, @"deleted": deletedClients, @"time": [NSDate date].transportString};
     
     NSInteger statusCode = 412;
     if (missedClients.count == 0) {
@@ -175,9 +175,9 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransport";
     
     NSString *onlyForUser = query[@"report_missing"];
     NSDictionary *missedClients = [self missedClientsFromRecipients:otrMetaData.recipients conversation:conversation sender:senderClient onlyForUserId:onlyForUser];
-    NSDictionary *redundantClients = [self redundantClientsFromRecipients:otrMetaData.recipients conversation:conversation];
+    NSDictionary *deletedClients = [self deletedClientsFromRecipients:otrMetaData.recipients conversation:conversation];
     
-    NSDictionary *payload = @{@"missing": missedClients, @"redundant": redundantClients, @"time": [NSDate date].transportString};
+    NSDictionary *payload = @{@"missing": missedClients, @"deleted": deletedClients, @"time": [NSDate date].transportString};
     
     NSInteger statusCode = 412;
     if (missedClients.count == 0) {

--- a/Source/Conversations/MockTransportSessionConversationsTests.m
+++ b/Source/Conversations/MockTransportSessionConversationsTests.m
@@ -285,13 +285,13 @@
                                                           selfUser.identifier: @[secondSelfClient.identifier],
                                                           otherUser.identifier: @[secondOtherUserClient.identifier]
                                                           },
-                                                  @"redundant": @{
+                                                  @"deleted": @{
                                                           otherUser.identifier: @[redundantClientId]
                                                           }
                                                   };
         
         AssertEqualDictionaries(expectedResponsePayload[@"missing"], response.payload.asDictionary[@"missing"]);
-        AssertEqualDictionaries(expectedResponsePayload[@"redundant"], response.payload.asDictionary[@"redundant"]);
+        AssertEqualDictionaries(expectedResponsePayload[@"deleted"], response.payload.asDictionary[@"deleted"]);
     }
     
     XCTAssertEqual(self.sut.generatedPushEvents.count, previousNotificationsCount);
@@ -468,13 +468,13 @@
                                                           selfUser.identifier: @[secondSelfClient.identifier],
                                                           otherUser.identifier: @[secondOtherUserClient.identifier]
                                                           },
-                                                  @"redundant": @{
+                                                  @"deleted": @{
                                                           otherUser.identifier: @[redundantClient.identifier]
                                                           }
                                                   };
         
         AssertEqualDictionaries(expectedResponsePayload[@"missing"], response.payload.asDictionary[@"missing"]);
-        AssertEqualDictionaries(expectedResponsePayload[@"redundant"], response.payload.asDictionary[@"redundant"]);
+        AssertEqualDictionaries(expectedResponsePayload[@"deleted"], response.payload.asDictionary[@"deleted"]);
     }
     
     XCTAssertEqual(self.sut.generatedPushEvents.count, previousNotificationsCount);
@@ -589,13 +589,13 @@
         
         NSDictionary *expectedResponsePayload = @{
                                                   @"missing": @{},
-                                                  @"redundant": @{
+                                                  @"deleted": @{
                                                           otherUser.identifier: @[redundantClientId]
                                                           }
                                                   };
         
         AssertEqualDictionaries(expectedResponsePayload[@"missing"], response.payload.asDictionary[@"missing"]);
-        AssertEqualDictionaries(expectedResponsePayload[@"redundant"], response.payload.asDictionary[@"redundant"]);
+        AssertEqualDictionaries(expectedResponsePayload[@"deleted"], response.payload.asDictionary[@"deleted"]);
     }
     
     XCTAssertEqual(self.sut.generatedPushEvents.count, previousNotificationsCount+3u);


### PR DESCRIPTION
## What's new in this PR?

### Issues

After deleting a client, mock transport will report that the deleted clients as `redundant` instead of `deleted`

### Causes

Mock transport has mixed up the concepts between deleted and redundant clients. A redundant clients is a client which is no longer in the conversation, in other words the user is no longer a participant of the conversation. A deleted client on the other is a client which no longer exist and the user still a participant of the conversation.

### Solutions

The existing method `redundantClientsFromRecipients` is in fact computing the deleted clients so we can just rename it.