### PR TITLE
Add mock endpoint for accepting legal hold

### DIFF
--- a/Resources/MockTransportSession.xcdatamodeld/TestTransportSession.xcdatamodel/contents
+++ b/Resources/MockTransportSession.xcdatamodeld/TestTransportSession.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14315.18" systemVersion="18D109" minimumToolsVersion="Xcode 4.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14490.99" systemVersion="19A471t" minimumToolsVersion="Xcode 4.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Asset" representedClassName="MockAsset" syncable="YES">
         <attribute name="contentType" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="conversation" optional="YES" attributeType="String" syncable="YES"/>
@@ -88,6 +88,7 @@
     </entity>
     <entity name="Team" representedClassName=".MockTeam" syncable="YES">
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="hasLegalHoldService" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="identifier" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="isBound" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
@@ -105,6 +106,7 @@
         <attribute name="identifier" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="isAccountDeleted" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="isEmailValidated" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="legalHoldRequest" optional="YES" attributeType="Binary" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="password" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="phone" optional="YES" attributeType="String" syncable="YES"/>
@@ -122,6 +124,7 @@
         <relationship name="inactiveConversations" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Conversation" syncable="YES"/>
         <relationship name="invitations" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="PersonalInvitation" inverseName="inviter" inverseEntity="PersonalInvitation" syncable="YES"/>
         <relationship name="memberships" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Member" inverseName="user" inverseEntity="Member" syncable="YES"/>
+        <relationship name="pendingLegalHoldClients" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserClient" inverseName="pendingLegalHoldUser" inverseEntity="UserClient" syncable="YES"/>
         <relationship name="pictures" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Picture" inverseName="user" inverseEntity="Picture" syncable="YES"/>
     </entity>
     <entity name="UserClient" representedClassName=".MockUserClient" syncable="YES">
@@ -137,6 +140,7 @@
         <attribute name="time" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="lastPrekey" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PreKey" inverseName="lastPrekeyOfClient" inverseEntity="PreKey" syncable="YES"/>
+        <relationship name="pendingLegalHoldUser" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="pendingLegalHoldClients" inverseEntity="User" syncable="YES"/>
         <relationship name="prekeys" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PreKey" inverseName="client" inverseEntity="PreKey" syncable="YES"/>
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="clients" inverseEntity="User" syncable="YES"/>
     </entity>
@@ -150,8 +154,8 @@
         <element name="Picture" positionX="0" positionY="0" width="128" height="120"/>
         <element name="PreKey" positionX="0" positionY="0" width="128" height="105"/>
         <element name="Service" positionX="9" positionY="153" width="128" height="135"/>
-        <element name="Team" positionX="9" positionY="153" width="128" height="180"/>
-        <element name="User" positionX="0" positionY="0" width="128" height="420"/>
-        <element name="UserClient" positionX="0" positionY="0" width="128" height="255"/>
+        <element name="Team" positionX="9" positionY="153" width="128" height="195"/>
+        <element name="User" positionX="0" positionY="0" width="128" height="450"/>
+        <element name="UserClient" positionX="0" positionY="0" width="128" height="270"/>
     </elements>
 </model>

--- a/Source/Clients and OTR/MockUserClient.swift
+++ b/Source/Clients and OTR/MockUserClient.swift
@@ -24,7 +24,10 @@ import CoreData
     
     /// User that owns the client
     @NSManaged public var user : MockUser?
-    
+
+    /// User that will own the client once legal hold is accepted.
+    @NSManaged public var pendingLegalHoldUser: MockUser?
+
     /// Remote identifier
     @NSManaged public var identifier : String?
     
@@ -84,9 +87,19 @@ extension MockUserClient {
     }
 }
 
+// MARK: - Legal Hold
+
+extension MockUserClient {
+
+    public var isLegalHoldDevice: Bool {
+        return type == "legalhold" || deviceClass == "legalhold"
+    }
+
+}
+
 // MARK: - JSON de/serialization
 @objc extension MockUserClient {
-    
+
     /// Creates a new client from JSON payload
     public static func insertClient(payload: [String:Any], context: NSManagedObjectContext) -> MockUserClient? {
         
@@ -136,9 +149,11 @@ extension MockUserClient {
     
     /// Insert a new client, automatically generate prekeys and last key
     @objc(insertClientWithLabel:type:deviceClass:user:context:)
-    public static func insertClient(label: String, type: String = "permanent", deviceClass: String = "phone", for user: MockUser, in context: NSManagedObjectContext) -> MockUserClient?
+    public static func insertClient(label: String, type: String = "permanent", deviceClass: String = "phone", for user: MockUser, isPendignLegalHold: Bool = false, in context: NSManagedObjectContext) -> MockUserClient?
     {
         let newClient = NSEntityDescription.insertNewObject(forEntityName: "UserClient", into: context) as! MockUserClient
+
+        if isPendingLegalHold
     
         newClient.user = user
         newClient.identifier = NSString.createAlphanumerical() as String
@@ -264,5 +279,5 @@ extension MockUserClient {
 }
 
 /// Allowed client types
-private let validClientTypes = Set(["temporary", "permanent"])
+private let validClientTypes = Set(["temporary", "permanent", "legalhold"])
 

--- a/Source/Teams/MockTeam.swift
+++ b/Source/Teams/MockTeam.swift
@@ -29,6 +29,7 @@ import CoreData
     @NSManaged public var identifier: String
     @NSManaged public var createdAt: Date
     @NSManaged public var isBound: Bool
+    @NSManaged public var hasLegalHoldService: Bool
 
     public static var entityName = "Team"
     

--- a/Source/Teams/MockTransportSession+teams.swift
+++ b/Source/Teams/MockTransportSession+teams.swift
@@ -42,6 +42,8 @@ extension MockTransportSession {
             response = fetchMembersForTeam(with: request.RESTComponents(index: 1))
         case "/teams/*/members/*":
             response = fetchMemberForTeam(withTeamId: request.RESTComponents(index: 1), userId: request.RESTComponents(index: 3))
+        case "/teams/*/legalhold/*/approve":
+            response = approveUserLegalHold(inTeam: request.RESTComponents(index: 1), forUser: request.RESTComponents(index: 3), payload: request.payload, method: request.method)
         default:
             break
         }
@@ -153,5 +155,43 @@ extension MockTransportSession {
         // All good, no error returned
         return nil
     }
-    
+
+    private func approveUserLegalHold(inTeam teamId: String?, forUser userId: String?, payload: ZMTransportData?, method: ZMTransportRequestMethod) -> ZMTransportResponse? {
+        // 1) Assert request contents
+        guard let teamId = teamId, let userId = userId else { return nil }
+        guard method == .methodPUT else { return nil }
+
+        // 2) Check the user in the team
+        let predicate = MockTeam.predicateWithIdentifier(identifier: teamId)
+        guard let team: MockTeam = MockTeam.fetch(in: managedObjectContext, withPredicate: predicate) else { return .teamNotFound }
+        guard let member = team.members.first(where: {$0.user.identifier == userId}) else { return .notTeamMember }
+
+        // 3) Check the password
+        guard let password = payload?.asDictionary()?["password"] as? String, password == member.user.password else {
+            return errorResponse(withCode: 409, reason: "missing-auth")
+        }
+
+        // 4) Check the legal hold state of the team and user
+        guard team.hasLegalHoldService else {
+            return errorResponse(withCode: 403, reason: "legalhold-not-enabled")
+        }
+
+        switch member.user.legalHoldState {
+        case .disabled:
+            return errorResponse(withCode: 412, reason: "legalhold-not-pending")
+        case .enabled:
+            return errorResponse(withCode: 409, reason: "legalhold-already-enabled")
+        case .pending(let request):
+            member.user.legalHoldRequest = nil
+            #warning("TODO: Add the legal hold client")
+        }
+
+        return ZMTransportResponse(payload: nil, httpStatus: 200, transportSessionError: nil)
+    }
+
+    private func errorResponse(withCode code: Int, reason: String) -> ZMTransportResponse {
+        let payload: NSDictionary = ["label": reason]
+        return ZMTransportResponse(payload: payload, httpStatus: code, transportSessionError: nil)
+    }
+
 }

--- a/Source/Teams/MockTransportSessionTeamTests.swift
+++ b/Source/Teams/MockTransportSessionTeamTests.swift
@@ -371,4 +371,50 @@ extension MockTransportSessionTeamTests {
         XCTAssertEqual(payload?["user"] as? String, user1.identifier)
     }
 
+    func testThatItDoesNotApproveLegalHoldRequestForNonPendingUser() {
+        var user: MockUser!
+        var team: MockTeam!
+
+        sut.performRemoteChanges { session in
+            user = session.insertSelfUser(withName: "one")
+            user.password = "Ex@mple!"
+
+            team = session.insertTeam(withName: "name", isBound: true, users: [user])
+            team.pictureAssetKey = "1234-abc"
+            team.pictureAssetId = "123-1234-abc"
+            team.hasLegalHoldService = true
+        }
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // Then
+        let path = "/teams/\(team.identifier)/legalhold/\(user.identifier)/approve"
+        let response = self.response(forPayload: ["password": "Ex@mple!"] as NSDictionary, path: path, method: .methodPUT)
+        XCTAssertNotNil(response)
+        XCTAssertEqual(response?.httpStatus, 200)
+        XCTAssertNotNil(response?.payload)
+    }
+
+    func testThatItApprovesLegalHoldRequest() {
+        var user: MockUser!
+        var team: MockTeam!
+
+        sut.performRemoteChanges { session in
+            user = session.insertSelfUser(withName: "one")
+            user.password = "Ex@mple!"
+
+            team = session.insertTeam(withName: "name", isBound: true, users: [user])
+            team.pictureAssetKey = "1234-abc"
+            team.pictureAssetId = "123-1234-abc"
+            team.hasLegalHoldService = true
+        }
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // Then
+        let path = "/teams/\(team.identifier)/legalhold/\(user.identifier)/approve"
+        let response = self.response(forPayload: ["password": "Ex@mple!"] as NSDictionary, path: path, method: .methodPUT)
+        XCTAssertNotNil(response)
+        XCTAssertEqual(response?.httpStatus, 200)
+        XCTAssertNotNil(response?.payload)
+    }
+
 }

--- a/Source/Users/MockUser.swift
+++ b/Source/Users/MockUser.swift
@@ -19,7 +19,62 @@
 import Foundation
 
 @objcMembers public class MockUser: NSManagedObject {
-    
+
+    public enum LegalHoldState {
+        case enabled
+        case pending(LegalHoldRequest)
+        case disabled
+    }
+
+    public struct LegalHoldRequest: Codable, Hashable {
+
+        public struct Prekey: Codable, Hashable {
+            public let id: Int
+            public let key: Data
+
+            public init(id: Int, key: Data) {
+                self.id = id
+                self.key = key
+            }
+        }
+
+        public let requesterIdentifier: UUID
+        public let targetUserIdentifier: UUID
+        public let clientIdentifier: String
+        public let lastPrekey: Prekey
+
+        // MARK: Initialization
+
+        public init(requesterIdentifier: UUID, targetUserIdentifier: UUID, clientIdentifier: String, lastPrekey: Prekey) {
+            self.requesterIdentifier = requesterIdentifier
+            self.targetUserIdentifier = targetUserIdentifier
+            self.clientIdentifier = clientIdentifier
+            self.lastPrekey = lastPrekey
+        }
+
+        // MARK: Codable
+
+        private enum CodingKeys: String, CodingKey {
+            case requesterIdentifier = "requester"
+            case targetUserIdentifier = "target_user"
+            case clientIdentifier = "client_id"
+            case lastPrekey = "last_prekey"
+        }
+
+        static func decode(from data: Data) -> LegalHoldRequest? {
+            let decoder = JSONDecoder()
+            decoder.dataDecodingStrategy = .base64
+            return try? decoder.decode(LegalHoldRequest.self, from: data)
+        }
+
+        func encode() -> Data? {
+            let encoder = JSONEncoder()
+            encoder.dataEncodingStrategy = .base64
+            return try? encoder.encode(self)
+        }
+
+    }
+
     public static let mutualFriendsKey = "mutual_friends"
     public static let totalMutualFriendsKey = "total_mutual_friends"
 
@@ -52,6 +107,10 @@ import Foundation
 
     @NSManaged public var serviceIdentifier: String?
     @NSManaged public var richProfile: NSArray?
+
+    public var userClients: Set<MockUserClient> {
+        return clients as! Set<MockUserClient>
+    }
 
     override public func awakeFromInsert() {
         if accentID == 0 {
@@ -88,6 +147,38 @@ extension MockUser {
         updatedValues.add(value)
         richProfile = updatedValues
     }
+}
+
+// MARK: - Legal Hold
+
+extension MockUser {
+
+    @NSManaged private var primitiveLegalHoldRequest: Data?
+
+    public var legalHoldState: LegalHoldState {
+        if userClients.any(\.isLegalHoldDevice) {
+            return .enabled
+        } else if let request = legalHoldRequest {
+            return .pending(request)
+        } else {
+            return .disabled
+        }
+    }
+
+    public var legalHoldRequest: LegalHoldRequest? {
+        get {
+            willAccessValue(forKey: "legalHoldRequest")
+            let value = primitiveLegalHoldRequest.flatMap(LegalHoldRequest.decode)
+            didAccessValue(forKey: "legalHoldRequest")
+            return value
+        }
+        set {
+            willChangeValue(forKey: "legalHoldRequest")
+            primitiveLegalHoldRequest = newValue.flatMap { $0.encode() }
+            didChangeValue(forKey: "legalHoldRequest")
+        }
+    }
+
 }
 
 // MARK: - Broadcasting


### PR DESCRIPTION
## What's new in this PR?

### Issues

We want to be able to test approving a legal hold for a user.

### Solutions

Implement the legal hold approval behavior from BE.

### To-Do

- [ ] Create the legal hold client (how do we store it? how do we update it?)