### PR TITLE
Update error label when password is incorrect

### DIFF
--- a/Source/Teams/MockTransportSession+teams.swift
+++ b/Source/Teams/MockTransportSession+teams.swift
@@ -170,7 +170,7 @@ extension MockTransportSession {
 
         // 3) Check the password
         guard let password = payload?.asDictionary()?["password"] as? String, password == member.user.password else {
-            return errorResponse(withCode: 409, reason: "missing-auth")
+            return errorResponse(withCode: 403, reason: "access-deined")
         }
 
         // 4) Check the legal hold state of the team and user

--- a/Source/Teams/MockTransportSession+teams.swift
+++ b/Source/Teams/MockTransportSession+teams.swift
@@ -170,7 +170,7 @@ extension MockTransportSession {
 
         // 3) Check the password
         guard let password = payload?.asDictionary()?["password"] as? String, password == member.user.password else {
-            return errorResponse(withCode: 403, reason: "access-deined")
+            return errorResponse(withCode: 403, reason: "access-denied")
         }
 
         // 4) Check the legal hold state of the team and user


### PR DESCRIPTION
## What's new in this PR?

Update error label when password is incorrect for a legal hold request.