### PR TITLE
Add support for deleting team conversations

### DIFF
--- a/Source/Conversations/MockTransportSession+conversations.m
+++ b/Source/Conversations/MockTransportSession+conversations.m
@@ -298,8 +298,11 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransport";
 - (ZMTransportResponse *)processConversationsGetConversation:(NSString *)conversationId;
 {
     MockConversation *conversation = [self conversationByIdentifier:conversationId];
+    
     if (conversation == nil) {
         return [ZMTransportResponse responseWithPayload:nil HTTPStatus:404 transportSessionError:nil];
+    } else if (![conversation.activeUsers containsObject:self.selfUser]) {
+        return [ZMTransportResponse responseWithPayload:nil HTTPStatus:403 transportSessionError:nil];
     }
     
     return [ZMTransportResponse responseWithPayload:conversation.transportData HTTPStatus:200 transportSessionError:nil];


### PR DESCRIPTION
## What's new in this PR?

- Add support for deleting team conversations on `/teams/<team_id>/conversations/<conv_id>`
- Return 403 when requesting an existing conversation which you are not a member of to match new backend behaviour.