### PR TITLE
Feature: get-conversation-roles

### DIFF
--- a/Resources/MockTransportSession.xcdatamodeld/TestTransportSession.xcdatamodel/contents
+++ b/Resources/MockTransportSession.xcdatamodeld/TestTransportSession.xcdatamodel/contents
@@ -39,6 +39,7 @@
         <relationship name="connection" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Connection" inverseName="conversation" inverseEntity="Connection" syncable="YES"/>
         <relationship name="creator" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="createdConversations" inverseEntity="User" syncable="YES"/>
         <relationship name="events" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Event" inverseName="conversation" inverseEntity="Event" syncable="YES"/>
+        <relationship name="roles" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Role" inverseName="conversation" inverseEntity="Role" syncable="YES"/>
         <relationship name="team" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Team" inverseName="conversations" inverseEntity="Team" syncable="YES"/>
     </entity>
     <entity name="Event" representedClassName="MockEvent" syncable="YES">
@@ -87,6 +88,7 @@
     <entity name="Role" representedClassName=".MockRole" syncable="YES">
         <attribute name="name" attributeType="String" syncable="YES"/>
         <relationship name="actions" toMany="YES" deletionRule="Nullify" destinationEntity="Action" inverseName="roles" inverseEntity="Action" syncable="YES"/>
+        <relationship name="conversation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Conversation" inverseName="roles" inverseEntity="Conversation" syncable="YES"/>
         <relationship name="team" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Team" inverseName="roles" inverseEntity="Team" syncable="YES"/>
     </entity>
     <entity name="Service" representedClassName=".MockService" syncable="YES">
@@ -166,17 +168,17 @@
         <element name="Action" positionX="9" positionY="153" width="128" height="75"/>
         <element name="Asset" positionX="0" positionY="0" width="128" height="135"/>
         <element name="Connection" positionX="0" positionY="0" width="128" height="135"/>
-        <element name="Conversation" positionX="0" positionY="0" width="128" height="330"/>
+        <element name="Conversation" positionX="0" positionY="0" width="128" height="345"/>
         <element name="Event" positionX="0" positionY="0" width="128" height="150"/>
         <element name="Member" positionX="18" positionY="162" width="128" height="90"/>
         <element name="PendingLegalHoldClient" positionX="18" positionY="162" width="128" height="105"/>
         <element name="PersonalInvitation" positionX="0" positionY="0" width="128" height="135"/>
         <element name="Picture" positionX="0" positionY="0" width="128" height="120"/>
         <element name="PreKey" positionX="0" positionY="0" width="128" height="135"/>
+        <element name="Role" positionX="18" positionY="162" width="128" height="105"/>
         <element name="Service" positionX="9" positionY="153" width="128" height="135"/>
         <element name="Team" positionX="9" positionY="153" width="128" height="210"/>
         <element name="User" positionX="0" positionY="0" width="128" height="450"/>
         <element name="UserClient" positionX="0" positionY="0" width="128" height="255"/>
-        <element name="Role" positionX="18" positionY="162" width="128" height="90"/>
     </elements>
 </model>

--- a/Source/Conversations/MockConversation.h
+++ b/Source/Conversations/MockConversation.h
@@ -25,6 +25,7 @@
 @class MockUser;
 @class MockEvent;
 @class MockUserClient;
+@class MockRole;
 
 typedef NS_ENUM(int16_t, ZMTConversationType) {
     ZMTConversationTypeGroup = 0,
@@ -59,6 +60,8 @@ typedef NS_ENUM(int16_t, ZMTConversationType) {
 @property (nonatomic, readonly, nonnull) NSOrderedSet *activeUsers;
 
 @property (nonatomic, readonly, nonnull) NSOrderedSet *events;
+
+@property (nonatomic, nullable) NSSet<MockRole *> *roles;
 
 @property (nonatomic, nullable) MockTeam *team;
 

--- a/Source/Conversations/MockConversation.m
+++ b/Source/Conversations/MockConversation.m
@@ -54,6 +54,7 @@
 @dynamic accessMode;
 @dynamic link;
 @dynamic receiptMode;
+@dynamic roles;
 
 + (instancetype)insertConversationIntoContext:(NSManagedObjectContext *)moc withSelfUser:(MockUser *)selfUser creator:(MockUser *)creator otherUsers:(NSArray *)otherUsers type:(ZMTConversationType)type
 {

--- a/Source/Conversations/MockConversation.swift
+++ b/Source/Conversations/MockConversation.swift
@@ -32,6 +32,23 @@ extension MockConversation {
         conversation.mutableOrderedSetValue(forKey: #keyPath(MockConversation.activeUsers)).addObjects(from: users)
         return conversation
     }
+    
+    @objc(insertConversationWithRolesIntoContext:withCreator:otherUsers:)
+    public static func insertConversationWithRolesInto(context: NSManagedObjectContext, creator: MockUser, otherUsers:[MockUser]) -> MockConversation {
+        let conversation = NSEntityDescription.insertNewObject(forEntityName: "Conversation", into: context) as! MockConversation
+        conversation.type = .group
+        conversation.team = nil
+        conversation.identifier = UUID.create().transportString()
+        conversation.creator = creator
+        conversation.mutableOrderedSetValue(forKey: #keyPath(MockConversation.activeUsers)).addObjects(from: otherUsers)
+        let roles = Set([
+                MockRole.insert(in: context, name: MockConversation.admin, actions: MockTeam.createAdminActions(context: context)),
+                MockRole.insert(in: context, name: MockConversation.member, actions: MockTeam.createMemberActions(context: context))
+            ])
+        conversation.roles = roles
+
+        return conversation
+    }
 
     @objc public static func defaultAccessMode(conversationType: ZMTConversationType, team: MockTeam?) -> [String] {
         let (accessMode, _) = defaultAccess(conversationType: conversationType, team: team)

--- a/Source/Conversations/MockTransportSession+conversations.m
+++ b/Source/Conversations/MockTransportSession+conversations.m
@@ -119,6 +119,9 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransport";
     else if ([request matchesWithPath:@"/conversations/*/receipt-mode" method:ZMMethodPUT]) {
         return [self processReceiptModeUpdateForConversation:[request RESTComponentAtIndex:1] payload:[request.payload asDictionary]];
     }
+    else if ([request matchesWithPath:@"/conversations/*/roles" method:ZMMethodGET]) {
+        return [self processFetchRolesForConversation:[request RESTComponentAtIndex:1] payload:[request.payload asDictionary]];
+    }
 
     return [ZMTransportResponse responseWithPayload:nil HTTPStatus:404 transportSessionError:nil];
 

--- a/Source/Conversations/MockTransportSession+conversations.swift
+++ b/Source/Conversations/MockTransportSession+conversations.swift
@@ -99,6 +99,19 @@ extension MockTransportSession {
                                              "code": "test-code"] as ZMTransportData, httpStatus: 200, transportSessionError: nil)
     }
     
+    @objc(processFetchRolesForConversation:payload:)
+    public func processFetchRoles(for conversationId: String, payload: [String: AnyHashable]) -> ZMTransportResponse {
+        guard let conversation = fetchConversation(with: conversationId) else {
+            return ZMTransportResponse(payload: nil, httpStatus: 404, transportSessionError: nil)
+        }
+        
+        let roles = conversation.team == nil ? conversation.roles! : conversation.team!.roles
+        let payload: [String : Any] = [
+            "conversation_roles" : roles.map { $0.payload }
+        ]
+        return ZMTransportResponse(payload: payload as ZMTransportData, httpStatus: 200, transportSessionError: nil)
+    }
+    
     @objc(processCreateLinkForConversation:payload:)
     public func processCreateLink(for conversationId: String, payload: [String: AnyHashable]) -> ZMTransportResponse {
         guard let conversation = fetchConversation(with: conversationId) else {

--- a/Source/Conversations/MockTransportSession+conversations.swift
+++ b/Source/Conversations/MockTransportSession+conversations.swift
@@ -105,7 +105,7 @@ extension MockTransportSession {
             return ZMTransportResponse(payload: nil, httpStatus: 404, transportSessionError: nil)
         }
         
-        let roles = conversation.team == nil ? conversation.roles! : conversation.team!.roles
+        let roles = conversation.team?.roles ?? conversation.roles!
         let payload: [String : Any] = [
             "conversation_roles" : roles.map { $0.payload }
         ]

--- a/Source/MockTransportSession.h
+++ b/Source/MockTransportSession.h
@@ -140,6 +140,7 @@ typedef ZMTransportResponse * _Nullable (^ZMCustomResponseGeneratorBlock)(ZMTran
 - (MockConversation *)insertOneOnOneConversationWithSelfUser:(MockUser *)selfUser otherUser:(MockUser *)otherUser;
 - (MockConversation *)insertGroupConversationWithSelfUser:(MockUser *)selfUser otherUsers:(NSArray *)otherUsers;
 - (MockConversation *)insertConversationWithSelfUser:(MockUser *)selfUser creator:(MockUser *)creator otherUsers:(nullable NSArray *)otherUsers type:(ZMTConversationType)conversationType;
+- (MockConversation *)insertConversationWithSelfUserAndGroupRoles:(MockUser *)selfUser otherUsers:(nullable NSArray *)otherUsers;
 - (MockConversation *)insertConversationWithCreator:(MockUser *)creator otherUsers:(NSArray *)otherUsers type:(ZMTConversationType)conversationType;
 
 - (MockAsset *)insertAssetWithID:(NSUUID *)assetID assetToken:(NSUUID *)assetToken assetData:(NSData *)assetData contentType:(NSString *)contentType;

--- a/Source/MockTransportSession.m
+++ b/Source/MockTransportSession.m
@@ -709,6 +709,11 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
     return [MockConversation insertConversationIntoContext:self.managedObjectContext withSelfUser:selfUser creator:creator otherUsers:otherUsers type:conversationType];
 }
 
+- (MockConversation *)insertConversationWithSelfUserAndGroupRoles:(MockUser *)selfUser otherUsers:(NSArray *)otherUsers;
+{
+    return [MockConversation insertConversationWithRolesIntoContext:self.managedObjectContext withCreator:selfUser otherUsers:otherUsers ];
+}
+
 - (MockConversation *)insertConversationWithCreator:(MockUser *)creator otherUsers:(NSArray *)otherUsers type:(ZMTConversationType)conversationType;
 {
     return [MockConversation insertConversationIntoContext:self.managedObjectContext creator:creator otherUsers:otherUsers type:conversationType];

--- a/Source/Teams/MockTeam.swift
+++ b/Source/Teams/MockTeam.swift
@@ -82,7 +82,7 @@ extension MockTeam {
         return payloadValues as NSDictionary
     }
     
-    private static func createAdminActions(context: NSManagedObjectContext) -> Set<MockAction> {
+    public static func createAdminActions(context: NSManagedObjectContext) -> Set<MockAction> {
         
         return  Set(["add_conversation_member",
                  "remove_conversation_member",
@@ -95,7 +95,7 @@ extension MockTeam {
                  "delete_convesation"].map{MockAction.insert(in: context, name: $0)})
     }
     
-    private static func createMemberActions(context: NSManagedObjectContext) -> Set<MockAction> {
+    public static func createMemberActions(context: NSManagedObjectContext) -> Set<MockAction> {
         
         return  Set(["leave_conversation"].map{MockAction.insert(in: context, name: $0)})
     }

--- a/Tests/Source/Conversations/MockTransportSessionConversationsTests.m
+++ b/Tests/Source/Conversations/MockTransportSessionConversationsTests.m
@@ -1412,9 +1412,6 @@
     
 }
 
-
-
-
 - (void)testThatItReturnsConversationsForSpecificIDs
 {
     // GIVEN


### PR DESCRIPTION
What's new in this PR?

- add endpoint GET conversations/:cid/roles
- add tests for a new endpoint
