### PR TITLE
Fix conversation typo

### DIFF
--- a/Source/Teams/MockTeam.swift
+++ b/Source/Teams/MockTeam.swift
@@ -92,7 +92,7 @@ extension MockTeam {
                  "modify_conversation_access",
                  "modify_other_conversation_member",
                  "leave_conversation",
-                 "delete_convesation"].map{MockAction.insert(in: context, name: $0)})
+                 "delete_conversation"].map{MockAction.insert(in: context, name: $0)})
     }
     
     public static func createMemberActions(context: NSManagedObjectContext) -> Set<MockAction> {

--- a/Tests/Source/Conversations/MockTransportSessionConversationsTests.swift
+++ b/Tests/Source/Conversations/MockTransportSessionConversationsTests.swift
@@ -198,7 +198,7 @@ class MockTransportSessionConversationsTests_Swift: MockTransportSessionTests {
             "modify_conversation_receipt_mode",
             "modify_conversation_access",
             "modify_other_conversation_member",
-            "leave_conversation","delete_convesation"
+            "leave_conversation","delete_conversation"
             ]))
         
         let member = conversationRoles.first(where: {($0["conversation_role"] as? String) == MockConversation.member})
@@ -243,7 +243,7 @@ class MockTransportSessionConversationsTests_Swift: MockTransportSessionTests {
             "modify_conversation_receipt_mode",
             "modify_conversation_access",
             "modify_other_conversation_member",
-            "leave_conversation","delete_convesation"
+            "leave_conversation","delete_conversation"
             ]))
         
         let member = conversationRoles.first(where: {($0["conversation_role"] as? String) == MockConversation.member})

--- a/Tests/Source/Teams/MockTransportSessionTeamTests.swift
+++ b/Tests/Source/Teams/MockTransportSessionTeamTests.swift
@@ -509,7 +509,7 @@ extension MockTransportSessionTeamTests {
             "modify_conversation_receipt_mode",
             "modify_conversation_access",
             "modify_other_conversation_member",
-            "leave_conversation","delete_convesation"
+            "leave_conversation","delete_conversation"
             ]))
         
         let member = conversationRoles.first(where: {($0["conversation_role"] as? String) == MockConversation.member})


### PR DESCRIPTION
## What's new in this PR?
There is a typo in `delete_conversation` action