### PR TITLE
[Fix] Include team property in user response

### DIFF
--- a/Source/Users/MockUser.swift
+++ b/Source/Users/MockUser.swift
@@ -238,6 +238,10 @@ extension MockUser {
                                       "id" : serviceIdentifier]
             }
             
+            if let team = self.memberships?.first?.team {
+                payload["team"] = team.identifier
+            }
+            
             return payload
         }
     }

--- a/Tests/Source/MockTransportSessionTests.m
+++ b/Tests/Source/MockTransportSessionTests.m
@@ -392,17 +392,26 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransportTests";
     NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithDictionary:(id) data];
     FHAssertTrue(fr, [dict isKindOfClass:[NSDictionary class]]);
     NSArray *keys = @[@"accent_id", @"id", @"name", @"picture", @"handle", @"assets"];
-    if(isSelf) {
+    if (isSelf) {
         keys = [keys arrayByAddingObjectsFromArray:@[@"email", @"phone"]];
+    }
+    
+    MockTeam *team = user.memberships.anyObject.team;
+    if (team != nil) {
+        keys = [keys arrayByAddingObjectsFromArray:@[@"team"]];
     }
     
     AssertDictionaryHasKeys(dict, keys);
     
     [user.managedObjectContext performBlockAndWait:^{
         
-        if(isSelf) {
+        if (isSelf) {
             FHAssertEqualObjects(fr, dict[@"email"], user.email);
             FHAssertEqual(fr, dict[@"phone"], user.phone);
+        }
+        
+        if (team != nil) {
+            FHAssertEqual(fr, dict[@"team"], team.identifier);
         }
         
         FHAssertEqualObjects(fr, dict[@"name"], user.name);


### PR DESCRIPTION
## What's new in this PR?

### Issues

The mock transport didn't include the `team` property when fetching a user if that user belongs to a team.

### Causes

Not implemented.

### Solutions

Check if user is a member of any team, and if so include the `team` property.