### PR TITLE
[Feature] Support for fetching team members by ID

### DIFF
--- a/Source/Teams/MockTransportSession+teams.swift
+++ b/Source/Teams/MockTransportSession+teams.swift
@@ -47,6 +47,10 @@ extension MockTransportSession {
             response = fetchMembersForTeam(with: request.RESTComponents(index: 1))
         case "/teams/*/members/*":
             response = fetchMemberForTeam(withTeamId: request.RESTComponents(index: 1), userId: request.RESTComponents(index: 3))
+        case "/teams/*/get-members-by-ids-using-post" where request.method == .methodPOST:
+            let payload = request.payload?.asDictionary()
+            let userIDs = payload?["user_ids"] as? [String]
+            response = fetchMembersForTeam(with: request.RESTComponents(index: 1), userIds: userIDs)
         case "/teams/*/legalhold/*/approve":
             response = approveUserLegalHold(inTeam: request.RESTComponents(index: 1), forUser: request.RESTComponents(index: 3), payload: request.payload, method: request.method)
         default:
@@ -145,9 +149,9 @@ extension MockTransportSession {
         return ZMTransportResponse(payload: nil, httpStatus: 201, transportSessionError: nil)
     }
     
-    private func fetchMembersForTeam(with identifier: String?) -> ZMTransportResponse? {
-        guard let identifier = identifier else { return nil }
-        let predicate = MockTeam.predicateWithIdentifier(identifier: identifier)
+    private func fetchMembersForTeam(with teamId: String?) -> ZMTransportResponse? {
+        guard let teamId = teamId else { return nil }
+        let predicate = MockTeam.predicateWithIdentifier(identifier: teamId)
         guard let team: MockTeam = MockTeam.fetch(in: managedObjectContext, withPredicate: predicate) else { return .teamNotFound }
         if let permissionError = ensurePermission(.getMemberPermissions, in: team) {
             return permissionError
@@ -157,6 +161,22 @@ extension MockTransportSession {
             "members" : team.members.map { $0.payload }
         ]
 
+        return ZMTransportResponse(payload: payload as ZMTransportData, httpStatus: 200, transportSessionError: nil)
+    }
+    
+    private func fetchMembersForTeam(with teamId: String?, userIds: [String]?) -> ZMTransportResponse? {
+        guard let teamId = teamId, let userIds = userIds else { return nil }
+        let predicate = MockTeam.predicateWithIdentifier(identifier: teamId)
+        guard let team: MockTeam = MockTeam.fetch(in: managedObjectContext, withPredicate: predicate) else { return .teamNotFound }
+        let members = team.members.filter({ userIds.contains($0.user.identifier) })
+        if let permissionError = ensurePermission(.getMemberPermissions, in: team) {
+            return permissionError
+        }
+        
+        let payload: [String : Any] = [
+            "members" : members.map { $0.payload }
+        ]
+        
         return ZMTransportResponse(payload: payload as ZMTransportData, httpStatus: 200, transportSessionError: nil)
     }
     


### PR DESCRIPTION
## What's new in this PR?

Add support for the new endpoint `/teams/<team_id>/get-members-by-ids-using-post`, which allows you fetch multiple team members by id.

