### PR TITLE
[Feature] Add hasMore property to the members response

### DIFF
--- a/Source/Teams/MockTransportSession+teams.swift
+++ b/Source/Teams/MockTransportSession+teams.swift
@@ -158,7 +158,8 @@ extension MockTransportSession {
         }
         
         let payload: [String : Any] = [
-            "members" : team.members.map { $0.payload }
+            "members" : team.members.map { $0.payload },
+            "hasMore" : false
         ]
 
         return ZMTransportResponse(payload: payload as ZMTransportData, httpStatus: 200, transportSessionError: nil)
@@ -174,7 +175,8 @@ extension MockTransportSession {
         }
         
         let payload: [String : Any] = [
-            "members" : members.map { $0.payload }
+            "members" : members.map { $0.payload },
+            "hasMore" : false
         ]
         
         return ZMTransportResponse(payload: payload as ZMTransportData, httpStatus: 200, transportSessionError: nil)


### PR DESCRIPTION
## What's new in this PR?

`hasMore` is a non-optional property on the members response to we should always include it. `hasMore` is `true` if the result has been truncated and it's not possible to fetch all members/