### PR TITLE
[Chore] Update data model to use secure encoding to avoid warnings

### DIFF
--- a/Resources/MockTransportSession.xcdatamodeld/TestTransportSession.xcdatamodel/contents
+++ b/Resources/MockTransportSession.xcdatamodeld/TestTransportSession.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14492.1" systemVersion="19B88" minimumToolsVersion="Xcode 4.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="16119" systemVersion="19E287" minimumToolsVersion="Xcode 4.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Action" representedClassName=".MockAction" syncable="YES">
         <attribute name="name" attributeType="String" syncable="YES"/>
         <relationship name="roles" toMany="YES" deletionRule="Nullify" destinationEntity="Role" inverseName="actions" inverseEntity="Role" syncable="YES"/>
@@ -21,7 +21,7 @@
         <relationship name="to" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="connectionsTo" inverseEntity="User" syncable="YES"/>
     </entity>
     <entity name="Conversation" representedClassName="MockConversation" syncable="YES">
-        <attribute name="accessMode" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="accessMode" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" syncable="YES"/>
         <attribute name="accessRole" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="identifier" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="link" optional="YES" attributeType="String" syncable="YES"/>
@@ -30,7 +30,7 @@
         <attribute name="otrArchivedRef" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="otrMuted" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="otrMutedRef" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="otrMutedStatus" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="otrMutedStatus" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" syncable="YES"/>
         <attribute name="receiptMode" optional="YES" attributeType="Integer 16" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="selfIdentifier" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="selfRole" attributeType="String" defaultValueString="wire_admin" syncable="YES"/>
@@ -44,7 +44,7 @@
         <relationship name="team" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Team" inverseName="conversations" inverseEntity="Team" syncable="YES"/>
     </entity>
     <entity name="Event" representedClassName="MockEvent" syncable="YES">
-        <attribute name="data" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="data" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" syncable="YES"/>
         <attribute name="decryptedOTRData" optional="YES" attributeType="Binary" syncable="YES"/>
         <attribute name="identifier" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="time" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
@@ -58,7 +58,7 @@
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="memberships" inverseEntity="User" syncable="YES"/>
     </entity>
     <entity name="ParticipantRole" representedClassName=".MockParticipantRole" syncable="YES">
-        <attribute name="modifiedKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="modifiedKeys" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" syncable="YES"/>
         <relationship name="conversation" maxCount="1" deletionRule="Nullify" destinationEntity="Conversation" inverseName="participantRoles" inverseEntity="Conversation" syncable="YES"/>
         <relationship name="role" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Role" inverseName="participantRoles" inverseEntity="Role" syncable="YES"/>
         <relationship name="user" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="participantRoles" inverseEntity="User" syncable="YES"/>
@@ -81,7 +81,7 @@
         <attribute name="contentLength" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="contentType" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="identifier" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="info" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="info" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" syncable="YES"/>
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="pictures" inverseEntity="User" syncable="YES"/>
     </entity>
     <entity name="PreKey" representedClassName="MockPreKey" syncable="YES">
@@ -140,7 +140,7 @@
         <attribute name="phone" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="previewProfileAssetIdentifier" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="providerIdentifier" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="richProfile" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="richProfile" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" syncable="YES"/>
         <attribute name="role" attributeType="String" defaultValueString="wire_admin" syncable="YES"/>
         <attribute name="serviceIdentifier" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="activeConversations" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Conversation" inverseName="activeUsers" inverseEntity="Conversation" syncable="YES"/>
@@ -177,18 +177,18 @@
         <element name="Action" positionX="9" positionY="153" width="128" height="75"/>
         <element name="Asset" positionX="0" positionY="0" width="128" height="135"/>
         <element name="Connection" positionX="0" positionY="0" width="128" height="135"/>
-        <element name="Conversation" positionX="0" positionY="0" width="128" height="30"/>
-        <element name="Event" positionX="0" positionY="0" width="128" height="150"/>
+        <element name="Conversation" positionX="0" positionY="0" width="128" height="358"/>
+        <element name="Event" positionX="0" positionY="0" width="128" height="148"/>
         <element name="Member" positionX="18" positionY="162" width="128" height="90"/>
-        <element name="ParticipantRole" positionX="18" positionY="162" width="128" height="30"/>
+        <element name="ParticipantRole" positionX="18" positionY="162" width="128" height="103"/>
         <element name="PendingLegalHoldClient" positionX="18" positionY="162" width="128" height="105"/>
         <element name="PersonalInvitation" positionX="0" positionY="0" width="128" height="135"/>
-        <element name="Picture" positionX="0" positionY="0" width="128" height="120"/>
+        <element name="Picture" positionX="0" positionY="0" width="128" height="118"/>
         <element name="PreKey" positionX="0" positionY="0" width="128" height="135"/>
         <element name="Role" positionX="18" positionY="162" width="128" height="30"/>
         <element name="Service" positionX="9" positionY="153" width="128" height="135"/>
         <element name="Team" positionX="9" positionY="153" width="128" height="210"/>
-        <element name="User" positionX="0" positionY="0" width="128" height="30"/>
+        <element name="User" positionX="0" positionY="0" width="128" height="463"/>
         <element name="UserClient" positionX="0" positionY="0" width="128" height="255"/>
     </elements>
 </model>


### PR DESCRIPTION
## What's new in this PR?

### Issues

We get warnings about entities in the `WireMockTransport` not using secure encoding when running tests in SE.

### Causes

We are not declaring that the transformable properties in the data model should use a secure encoder/decoder.

### Solutions

Declare transformable properties to use `NSSecureUnarchiveFromData`