### PR TITLE
Fix: "Multiple methods named 'allKeys' found" in XCode 12

### DIFF
--- a/Source/Clients and OTR/MockTransportSession+OTR.m
+++ b/Source/Clients and OTR/MockTransportSession+OTR.m
@@ -42,29 +42,6 @@
     return [self missedClients:recipients users:self.selfUser.connectionsAndTeamMembers sender:sender onlyForUserId:onlyForUserId];
 }
 
-- (NSDictionary *)missedClients:(NSDictionary *)recipients users:(NSSet<MockUser *> *)users sender:(MockUserClient *)sender onlyForUserId:(NSString *)onlyForUserId
-{
-    NSMutableDictionary *missedClients = [NSMutableDictionary new];
-    for (MockUser *user in users) {
-        if (onlyForUserId != nil && ![[NSUUID uuidWithTransportString:user.identifier] isEqual:[NSUUID uuidWithTransportString:onlyForUserId]]) {
-            continue;
-        }
-        NSArray *recipientClients = [recipients[user.identifier] allKeys];
-        NSSet *userClients = [user.clients mapWithBlock:^id(MockUserClient *client) {
-            if (client != sender) {
-                return client.identifier;
-            }
-            return nil;
-        }];
-        
-        NSMutableSet *userMissedClients = [userClients mutableCopy];
-        [userMissedClients minusSet:[NSSet setWithArray:recipientClients]];
-        if (userMissedClients.count > 0) {
-            missedClients[user.identifier] = userMissedClients.allObjects;
-        }
-    }
-    return missedClients;
-}
 
 - (NSDictionary *)deletedClients:(NSDictionary *)recipients conversation:(MockConversation *)conversation
 {

--- a/Source/Clients and OTR/MockTransportSession+OTR.swift
+++ b/Source/Clients and OTR/MockTransportSession+OTR.swift
@@ -33,13 +33,9 @@ extension MockTransportSession {
             }
             let recipientClients = (recipients?[user.identifier] as AnyObject).keys
             let clients: Set<MockUserClient> = user.userClients
-            let userClients = clients.compactMap { (client) -> String? in
-                if client != sender {
-                    return client.identifier
-                }
-
-                return nil
-            }
+            let userClients = clients
+                .filter { $0 != sender }
+                .map(\.identifier)
                 
             var userMissedClients = Set<AnyHashable>(userClients)
             userMissedClients.subtract(Set<AnyHashable>(arrayLiteral: recipientClients))

--- a/Source/Clients and OTR/MockTransportSession+OTR.swift
+++ b/Source/Clients and OTR/MockTransportSession+OTR.swift
@@ -32,16 +32,18 @@ extension MockTransportSession {
                 continue
             }
             let recipientClients = (recipients?[user.identifier] as AnyObject).keys
-            let userClients = user.clients.map({ client in
-                if client as? MockUserClient != sender {
-                    return (client as? MockUserClient)?.identifier
+            let clients: Set<MockUserClient> = user.userClients
+            let userClients = clients.compactMap { (client) -> String? in
+                if client != sender {
+                    return client.identifier
                 }
+
                 return nil
-            })
-    
-            var userMissedClients = userClients
-            userMissedClients?.subtract(Set<AnyHashable>(arrayLiteral: recipientClients))
-            if userMissedClients?.isEmpty == false {
+            }
+                
+            var userMissedClients = Set<AnyHashable>(userClients)
+            userMissedClients.subtract(Set<AnyHashable>(arrayLiteral: recipientClients))
+            if userMissedClients.isEmpty == false {
                 missedClients[user.identifier] = Array(arrayLiteral: userMissedClients)
             }
         }

--- a/WireMockTransport.xcodeproj/project.pbxproj
+++ b/WireMockTransport.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		7C52BFF82033225500297DDA /* MockReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C52BFF62033225500297DDA /* MockReachability.m */; };
 		872A2EE01FFE761B00900B22 /* MockService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872A2EDF1FFE761B00900B22 /* MockService.swift */; };
 		872A2EE21FFE7EE700900B22 /* MockTransportSession+Services.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872A2EE11FFE7EE700900B22 /* MockTransportSession+Services.swift */; };
+		A95FA87425DC155B0072786A /* MockTransportSessionPushChannelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95FA87325DC155B0072786A /* MockTransportSessionPushChannelTests.swift */; };
 		BF0F77831E93AC550060494E /* WireCryptobox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF0F777B1E93AC550060494E /* WireCryptobox.framework */; };
 		BF0F77841E93AC550060494E /* WireProtos.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF0F777C1E93AC550060494E /* WireProtos.framework */; };
 		BF0F77851E93AC550060494E /* WireTransport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF0F777D1E93AC550060494E /* WireTransport.framework */; };
@@ -248,6 +249,7 @@
 		872A2EDF1FFE761B00900B22 /* MockService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockService.swift; sourceTree = "<group>"; };
 		872A2EE11FFE7EE700900B22 /* MockTransportSession+Services.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockTransportSession+Services.swift"; sourceTree = "<group>"; };
 		872A2EE31FFE85D000900B22 /* MockServicesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockServicesTests.swift; sourceTree = "<group>"; };
+		A95FA87325DC155B0072786A /* MockTransportSessionPushChannelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTransportSessionPushChannelTests.swift; sourceTree = "<group>"; };
 		BF0F777B1E93AC550060494E /* WireCryptobox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WireCryptobox.framework; path = Carthage/Build/iOS/WireCryptobox.framework; sourceTree = "<group>"; };
 		BF0F777C1E93AC550060494E /* WireProtos.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WireProtos.framework; path = Carthage/Build/iOS/WireProtos.framework; sourceTree = "<group>"; };
 		BF0F777D1E93AC550060494E /* WireTransport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WireTransport.framework; path = Carthage/Build/iOS/WireTransport.framework; sourceTree = "<group>"; };
@@ -330,6 +332,7 @@
 				F157FE9D2060053500BC25F1 /* MockTransportSessionTests.h */,
 				54AE5A9F1B78FA62002757E9 /* MockTransportSessionTests.m */,
 				54AE5A9A1B78FA62002757E9 /* MockTransportSessionPushChannelTests.m */,
+				A95FA87325DC155B0072786A /* MockTransportSessionPushChannelTests.swift */,
 				F1519B5D1EC0A30100AD4E33 /* MockTransportSessionTests.swift */,
 				541797641CE1F86500C7646D /* MockTransportSessionCancelationTests.swift */,
 				54FAE6801E3A01F000E6DE42 /* MockTransportSessionObjectCreationTests.swift */,
@@ -960,6 +963,7 @@
 				F157FE95206000AC00BC25F1 /* MockTransportSessionBroadcastTests.swift in Sources */,
 				F157FE89205FFF7900BC25F1 /* MockTransportSessionLoginTests.m in Sources */,
 				541797651CE1F86500C7646D /* MockTransportSessionCancelationTests.swift in Sources */,
+				A95FA87425DC155B0072786A /* MockTransportSessionPushChannelTests.swift in Sources */,
 				F119FC1C2044551200969615 /* MockTransportSessionConversationAccessTests.swift in Sources */,
 				54FAE6821E3A025500E6DE42 /* MockTransportSessionObjectCreationTests.swift in Sources */,
 				F190E0951E8C0286003E81F8 /* MockUserTests.swift in Sources */,

--- a/WireMockTransport.xcodeproj/project.pbxproj
+++ b/WireMockTransport.xcodeproj/project.pbxproj
@@ -70,7 +70,6 @@
 		7C52BFF82033225500297DDA /* MockReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C52BFF62033225500297DDA /* MockReachability.m */; };
 		872A2EE01FFE761B00900B22 /* MockService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872A2EDF1FFE761B00900B22 /* MockService.swift */; };
 		872A2EE21FFE7EE700900B22 /* MockTransportSession+Services.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872A2EE11FFE7EE700900B22 /* MockTransportSession+Services.swift */; };
-		A95FA87425DC155B0072786A /* MockTransportSessionPushChannelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95FA87325DC155B0072786A /* MockTransportSessionPushChannelTests.swift */; };
 		BF0F77831E93AC550060494E /* WireCryptobox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF0F777B1E93AC550060494E /* WireCryptobox.framework */; };
 		BF0F77841E93AC550060494E /* WireProtos.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF0F777C1E93AC550060494E /* WireProtos.framework */; };
 		BF0F77851E93AC550060494E /* WireTransport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF0F777D1E93AC550060494E /* WireTransport.framework */; };
@@ -249,7 +248,6 @@
 		872A2EDF1FFE761B00900B22 /* MockService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockService.swift; sourceTree = "<group>"; };
 		872A2EE11FFE7EE700900B22 /* MockTransportSession+Services.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockTransportSession+Services.swift"; sourceTree = "<group>"; };
 		872A2EE31FFE85D000900B22 /* MockServicesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockServicesTests.swift; sourceTree = "<group>"; };
-		A95FA87325DC155B0072786A /* MockTransportSessionPushChannelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTransportSessionPushChannelTests.swift; sourceTree = "<group>"; };
 		BF0F777B1E93AC550060494E /* WireCryptobox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WireCryptobox.framework; path = Carthage/Build/iOS/WireCryptobox.framework; sourceTree = "<group>"; };
 		BF0F777C1E93AC550060494E /* WireProtos.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WireProtos.framework; path = Carthage/Build/iOS/WireProtos.framework; sourceTree = "<group>"; };
 		BF0F777D1E93AC550060494E /* WireTransport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WireTransport.framework; path = Carthage/Build/iOS/WireTransport.framework; sourceTree = "<group>"; };
@@ -332,7 +330,6 @@
 				F157FE9D2060053500BC25F1 /* MockTransportSessionTests.h */,
 				54AE5A9F1B78FA62002757E9 /* MockTransportSessionTests.m */,
 				54AE5A9A1B78FA62002757E9 /* MockTransportSessionPushChannelTests.m */,
-				A95FA87325DC155B0072786A /* MockTransportSessionPushChannelTests.swift */,
 				F1519B5D1EC0A30100AD4E33 /* MockTransportSessionTests.swift */,
 				541797641CE1F86500C7646D /* MockTransportSessionCancelationTests.swift */,
 				54FAE6801E3A01F000E6DE42 /* MockTransportSessionObjectCreationTests.swift */,
@@ -963,7 +960,6 @@
 				F157FE95206000AC00BC25F1 /* MockTransportSessionBroadcastTests.swift in Sources */,
 				F157FE89205FFF7900BC25F1 /* MockTransportSessionLoginTests.m in Sources */,
 				541797651CE1F86500C7646D /* MockTransportSessionCancelationTests.swift in Sources */,
-				A95FA87425DC155B0072786A /* MockTransportSessionPushChannelTests.swift in Sources */,
 				F119FC1C2044551200969615 /* MockTransportSessionConversationAccessTests.swift in Sources */,
 				54FAE6821E3A025500E6DE42 /* MockTransportSessionObjectCreationTests.swift in Sources */,
 				F190E0951E8C0286003E81F8 /* MockUserTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

On Xcode 12 this line does not compile for error ` Multiple methods named 'allKeys' found`
`NSArray *recipientClients = [recipients[user.identifier] allKeys];`

Convert the method to Swift to prevent this error.