### PR TITLE
[Feature] Add support for federated user search

### DIFF
--- a/Resources/MockTransportSession.xcdatamodeld/TestTransportSession.xcdatamodel/contents
+++ b/Resources/MockTransportSession.xcdatamodeld/TestTransportSession.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="16119" systemVersion="19E287" minimumToolsVersion="Xcode 4.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17709" systemVersion="20D91" minimumToolsVersion="Xcode 4.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Action" representedClassName=".MockAction" syncable="YES">
         <attribute name="name" attributeType="String" syncable="YES"/>
         <relationship name="roles" toMany="YES" deletionRule="Nullify" destinationEntity="Role" inverseName="actions" inverseEntity="Role" syncable="YES"/>
@@ -130,6 +130,7 @@
     <entity name="User" representedClassName=".MockUser" syncable="YES">
         <attribute name="accentID" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="completeProfileAssetIdentifier" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="domain" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="handle" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="identifier" optional="YES" attributeType="String" syncable="YES"/>
@@ -188,7 +189,7 @@
         <element name="Role" positionX="18" positionY="162" width="128" height="30"/>
         <element name="Service" positionX="9" positionY="153" width="128" height="135"/>
         <element name="Team" positionX="9" positionY="153" width="128" height="210"/>
-        <element name="User" positionX="0" positionY="0" width="128" height="463"/>
+        <element name="User" positionX="0" positionY="0" width="128" height="464"/>
         <element name="UserClient" positionX="0" positionY="0" width="128" height="255"/>
     </elements>
 </model>

--- a/Source/Clients and OTR/MockTransportSession+OTR.swift
+++ b/Source/Clients and OTR/MockTransportSession+OTR.swift
@@ -31,16 +31,16 @@ extension MockTransportSession {
                NSUUID(transport: user.identifier) != NSUUID(transport: onlyForUserId) {
                 continue
             }
-            let recipientClients = (recipients?[user.identifier] as AnyObject).keys
+            let recipientClients = (recipients?[user.identifier] as? [String: Any] ?? [:]).keys
             let clients: Set<MockUserClient> = user.userClients
             let userClients = clients
                 .filter { $0 != sender }
-                .map(\.identifier)
-                
-            var userMissedClients = Set<AnyHashable>(userClients)
-            userMissedClients.subtract(Set<AnyHashable>(arrayLiteral: recipientClients))
+                .compactMap(\.identifier)
+
+            var userMissedClients = Set(userClients)
+            userMissedClients.subtract(recipientClients)
             if userMissedClients.isEmpty == false {
-                missedClients[user.identifier] = Array(arrayLiteral: userMissedClients)
+                missedClients[user.identifier] = Array(userMissedClients)
             }
         }
         return missedClients

--- a/Source/MockTransportSession.h
+++ b/Source/MockTransportSession.h
@@ -66,6 +66,9 @@ typedef ZMTransportResponse * _Nullable (^ZMCustomResponseGeneratorBlock)(ZMTran
 @property (nonatomic) BOOL disableEnqueueRequests;
 @property (nonatomic) BOOL doNotRespondToRequests; //to simulate offline
 
+/// List of domains which the backend is federated with
+@property (nonatomic) NSArray<NSString *> *federatedDomains;
+
 @property (nonatomic, readonly) NSArray *updateEvents;
 
 @property (nonatomic, readwrite) id<ReachabilityProvider, TearDownCapable> reachability;

--- a/Source/Users/MockTransportSession+users.m
+++ b/Source/Users/MockTransportSession+users.m
@@ -68,6 +68,11 @@
     else if ([request matchesWithPath:@"/users/handles" method:ZMMethodPOST]) {
         return [self processUserHandleAvailabilityRequest:request.payload];
     }
+    else if ([request matchesWithPath:@"/users/by-handle/*/*" method:ZMMethodGET]) {
+        return [self processFederatedUserHandleRequest:[request RESTComponentAtIndex:2]
+                                                domain:[request RESTComponentAtIndex:3]
+                                                  path:request.path];
+    }
     else if ([request matchesWithPath:@"/users/*/prekeys" method:ZMMethodGET]) {
         return [self processSingleUserPreKeysRequest:[request RESTComponentAtIndex:1]];
     }
@@ -412,6 +417,7 @@
 }
 
 // MARK: - Handles
+
 - (ZMTransportResponse *)processUserHandleRequest:(NSString *)handle path:(NSString *)path;
 {
     NSFetchRequest *fetchRequest = [MockUser sortedFetchRequest];
@@ -421,6 +427,30 @@
     NSInteger statusCode;
 
     if(users.count > 0) {
+        statusCode = 200;
+        MockUser *user = users[0];
+        id <ZMTransportData> payload = [user transportData];
+        payloadData = [NSJSONSerialization dataWithJSONObject:payload options:0 error:nil];
+    }
+    else {
+        statusCode = 404;
+    }
+
+    NSHTTPURLResponse *urlResponse = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:path] statusCode:statusCode HTTPVersion:nil headerFields:@{@"Content-Type": @"application/json"}];
+    return [[ZMTransportResponse alloc] initWithHTTPURLResponse:urlResponse data:payloadData error:nil];;
+}
+
+- (ZMTransportResponse *)processFederatedUserHandleRequest:(NSString *)handle
+                                                    domain:(NSString *)domain
+                                                      path:(NSString *)path;
+{
+    NSFetchRequest *fetchRequest = [MockUser sortedFetchRequest];
+    fetchRequest.predicate = [NSPredicate predicateWithFormat:@"handle == %@ AND domain == %@", handle, domain];
+    NSArray *users = [self.managedObjectContext executeFetchRequestOrAssert:fetchRequest];
+    NSData *payloadData;
+    NSInteger statusCode;
+
+    if (users.count > 0) {
         statusCode = 200;
         MockUser *user = users[0];
         id <ZMTransportData> payload = [user transportData];

--- a/Source/Users/MockTransportSession+users.m
+++ b/Source/Users/MockTransportSession+users.m
@@ -70,7 +70,7 @@
     }
     else if ([request matchesWithPath:@"/users/by-handle/*/*" method:ZMMethodGET]) {
         return [self processFederatedUserHandleRequest:[request RESTComponentAtIndex:2]
-                                                domain:[request RESTComponentAtIndex:3]
+                                                handle:[request RESTComponentAtIndex:3]
                                                   path:request.path];
     }
     else if ([request matchesWithPath:@"/users/*/prekeys" method:ZMMethodGET]) {
@@ -440,8 +440,8 @@
     return [[ZMTransportResponse alloc] initWithHTTPURLResponse:urlResponse data:payloadData error:nil];;
 }
 
-- (ZMTransportResponse *)processFederatedUserHandleRequest:(NSString *)handle
-                                                    domain:(NSString *)domain
+- (ZMTransportResponse *)processFederatedUserHandleRequest:(NSString *)domain
+                                                    handle:(NSString *)handle
                                                       path:(NSString *)path;
 {
     NSFetchRequest *fetchRequest = [MockUser sortedFetchRequest];
@@ -450,7 +450,10 @@
     NSData *payloadData;
     NSInteger statusCode;
 
-    if (users.count > 0) {
+    if (![self.federatedDomains containsObject:domain]) {
+        statusCode = 422;
+    }
+    else if (users.count > 0) {
         statusCode = 200;
         MockUser *user = users[0];
         id <ZMTransportData> payload = [user transportData];

--- a/Source/Users/MockUser.swift
+++ b/Source/Users/MockUser.swift
@@ -29,6 +29,7 @@ import Foundation
     public static let mutualFriendsKey = "mutual_friends"
     public static let totalMutualFriendsKey = "total_mutual_friends"
 
+    @NSManaged public var domain: String?
     @NSManaged public var email: String?
     @NSManaged public var password: String?
     @NSManaged public var phone: String?
@@ -240,6 +241,13 @@ extension MockUser {
             
             if let team = self.memberships?.first?.team {
                 payload["team"] = team.identifier
+            }
+
+            if let domain = domain {
+                payload["qualified_id"] = [
+                    "id": identifier,
+                    "domain": domain
+                ]
             }
             
             return payload

--- a/Tests/Source/MockTransportSessionTests.m
+++ b/Tests/Source/MockTransportSessionTests.m
@@ -400,6 +400,10 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransportTests";
     if (team != nil) {
         keys = [keys arrayByAddingObjectsFromArray:@[@"team"]];
     }
+
+    if (user.domain != nil) {
+        keys = [keys arrayByAddingObjectsFromArray:@[@"qualified_id"]];
+    }
     
     AssertDictionaryHasKeys(dict, keys);
     

--- a/Tests/Source/MockTransportSessionTests.m
+++ b/Tests/Source/MockTransportSessionTests.m
@@ -417,6 +417,11 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransportTests";
         if (team != nil) {
             FHAssertEqual(fr, dict[@"team"], team.identifier);
         }
+
+        if (user.domain != nil) {
+            FHAssertEqualObjects(fr, dict[@"qualified_id"][@"domain"], user.domain);
+            FHAssertEqualObjects(fr, dict[@"qualified_id"][@"id"], user.identifier);
+        }
         
         FHAssertEqualObjects(fr, dict[@"name"], user.name);
         FHAssertEqualObjects(fr, dict[@"id"], user.identifier);

--- a/Tests/Source/Users/MockTransportSessionUsersTests.m
+++ b/Tests/Source/Users/MockTransportSessionUsersTests.m
@@ -701,7 +701,7 @@
 
 }
 
-- (void)testThatItFindsAnExhistingHandle_GET
+- (void)testThatItFindsAnExistingHandle_GET
 {
     // GIVEN
     NSString *handle = @"foobar22222";
@@ -720,7 +720,7 @@
     [self checkThatTransportData:response.payload matchesUser:user isSelfUser:NO failureRecorder:NewFailureRecorder()];
 }
 
-- (void)testThatItFindsAnExhistingHandle_HEAD
+- (void)testThatItFindsAnExistingHandle_HEAD
 {
     // GIVEN
     NSString *handle = @"foobar22222";
@@ -740,7 +740,7 @@
     [self checkThatTransportData:response.payload matchesUser:user isSelfUser:NO failureRecorder:NewFailureRecorder()];
 }
 
-- (void)testThatItDoesNotFindANonExhistingHandle
+- (void)testThatItDoesNotFindANonExistingHandle
 {
     // GIVEN
     NSString *handle = @"foobar22222";
@@ -749,6 +749,42 @@
     NSString *path = [@"/users/handles/" stringByAppendingPathComponent:handle];
     ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET];
     
+    // THEN
+    XCTAssertEqual(response.HTTPStatus, 404);
+    XCTAssertEqualObjects(response.rawResponse.URL.path, path);
+}
+
+- (void)testThatItFindsAnExistingFederatedUserByHandle_GET
+{
+    // GIVEN
+    NSString *handle = @"john";
+    NSString *domain = @"example.com";
+    __block MockUser *user;
+    [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
+        user = [session insertUserWithName:@"The other"];
+        user.handle = handle;
+        user.domain = domain;
+    }];
+
+    // WHEN
+    NSString *path = [[@"/users/by-handle/" stringByAppendingPathComponent:handle] stringByAppendingPathComponent:domain];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET];
+
+    // THEN
+    XCTAssertEqual(response.HTTPStatus, 200);
+    [self checkThatTransportData:response.payload matchesUser:user isSelfUser:NO failureRecorder:NewFailureRecorder()];
+}
+
+- (void)testThatItDoesNotFindAnNonExistingFederatedUserByHandle_GET
+{
+    // GIVEN
+    NSString *handle = @"john";
+    NSString *domain = @"example.com";
+
+    // WHEN
+    NSString *path = [[@"/users/by-handle/" stringByAppendingPathComponent:handle] stringByAppendingPathComponent:domain];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET];
+
     // THEN
     XCTAssertEqual(response.HTTPStatus, 404);
     XCTAssertEqualObjects(response.rawResponse.URL.path, path);


### PR DESCRIPTION
## What's new in this PR?

- Add support for federated user search by implementing `/users/by-handle/<handle>/<domain>`
- Add support for qualified IDs on the `MockUser`
- Add support for configuring federated domains using the `federatedDomains` property.