### PR TITLE
[Chore] Fix broken integration tests

### DIFF
--- a/Source/Clients and OTR/MockTransportSession+Clients.m
+++ b/Source/Clients and OTR/MockTransportSession+Clients.m
@@ -48,7 +48,7 @@
     else if ([request matchesWithPath:@"/clients/*/prekeys" method:ZMMethodGET]) {
         return [self processClientPreKeysForClient:[request RESTComponentAtIndex:1]];
     }
-    return [self errorResponseWithCode:400 reason:@"invalid method"];
+    return [self errorResponseWithCode:404 reason:@"no-endpoint"];
 }
 
 static NSInteger const MaxUserClientsAllowed = 2;

--- a/Source/Login/MockTransportSession+login.m
+++ b/Source/Login/MockTransportSession+login.m
@@ -94,7 +94,7 @@ static NSString * const HardcodedAccessToken = @"5hWQOipmcwJvw7BVwikKKN4glSue1Q7
         NSDictionary *headers = @{ @"Set-Cookie": [NSString stringWithFormat:@"zuid=%@", cookiesValue] };
         return [ZMTransportResponse responseWithPayload:responsePayload HTTPStatus:200 transportSessionError:nil headers:headers];
     }
-    return [self errorResponseWithCode:400 reason:@"invalid-method"];
+    return [self errorResponseWithCode:404 reason:@"no-endpoint"];
 }
 
 /// handles /login/send
@@ -120,7 +120,7 @@ static NSString * const HardcodedAccessToken = @"5hWQOipmcwJvw7BVwikKKN4glSue1Q7
         }
         
     }
-    return [self errorResponseWithCode:400 reason:@"invalid-method"];
+    return [self errorResponseWithCode:404 reason:@"no-endpoint"];
 }
 
 

--- a/Source/MockTransportSession.m
+++ b/Source/MockTransportSession.m
@@ -503,7 +503,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
         }
     } else {
         LogNetwork(@"<--- Response to %@: 404 (request not handled)", request.path);
-        response = [self errorResponseWithCode:404 reason:@"not implemented"];
+        response = [self errorResponseWithCode:404 reason:@"no-endpoint"];
         if(completionHandler) {
             completionHandler(response);
         }

--- a/Source/Notification Stream/MockTransportSession+notifications.m
+++ b/Source/Notification Stream/MockTransportSession+notifications.m
@@ -28,7 +28,7 @@
         return [ZMTransportResponse responseWithPayload:nil HTTPStatus:200 transportSessionError:nil];
     }
     
-    return [self errorResponseWithCode:400 reason:@"invalid-method"];
+    return [self errorResponseWithCode:404 reason:@"no-endpoint"];
 }
 
 
@@ -76,7 +76,7 @@
         }
     }
     else {
-        return [self errorResponseWithCode:400 reason:@"invalid-method"];
+        return [self errorResponseWithCode:404 reason:@"no-endpoint"];
     }
 }
 

--- a/Source/Registration/MockTransportSession+registration.m
+++ b/Source/Registration/MockTransportSession+registration.m
@@ -130,7 +130,7 @@
         return [ZMTransportResponse responseWithPayload:payload HTTPStatus:200 transportSessionError:nil headers:@{@"Set-Cookie": [NSString stringWithFormat:@"zuid=%@", cookiesValue]}];
     }
     
-    return [self errorResponseWithCode:400 reason:@"invalid-method"];
+    return [self errorResponseWithCode:404 reason:@"no-endpoint"];
 }
 
 /// Handles "/activate"
@@ -191,7 +191,7 @@
             return [self errorResponseWithCode:404 reason:@"not-found"];
         }
     }
-    return [self errorResponseWithCode:400 reason:@"invalid-method"];
+    return [self errorResponseWithCode:404 reason:@"no-endpoint"];
 }
 
 
@@ -233,7 +233,7 @@
         return [ZMTransportResponse responseWithPayload:nil HTTPStatus:200 transportSessionError:nil];
     }
     
-    return [self errorResponseWithCode:400 reason:@"invalid-method"];
+    return [self errorResponseWithCode:404 reason:@"no-endpoint"];
 }
 
 @end

--- a/Source/Search/MockTransportSession+search.m
+++ b/Source/Search/MockTransportSession+search.m
@@ -62,7 +62,7 @@
         return [ZMTransportResponse responseWithPayload:responsePayload HTTPStatus:200 transportSessionError:nil];
     }
     
-    return [self errorResponseWithCode:400 reason:@"invalid-method"];
+    return [self errorResponseWithCode:404 reason:@"no-endpoint"];
 }
 
 // handles /onboarding
@@ -95,7 +95,7 @@
         return [ZMTransportResponse responseWithPayload:@{@"results" : results} HTTPStatus:200 transportSessionError:nil];
         
     }
-    return [self errorResponseWithCode:400 reason:@"invalid-method"];
+    return [self errorResponseWithCode:404 reason:@"no-endpoint"];
 }
 
 

--- a/Tests/Source/Registration/MockTransportSessionRegistrationTests.m
+++ b/Tests/Source/Registration/MockTransportSessionRegistrationTests.m
@@ -60,7 +60,7 @@
     return user;
 }
 
-- (void)testThatRegistrationReturns400OnWrongMethod
+- (void)testThatRegistrationReturns404OnWrongMethod
 {
     // GIVEN
     ZMTransportRequestMethod methods[] = {ZMMethodHEAD, ZMMethodGET, ZMMethodDELETE, ZMMethodPUT};
@@ -75,7 +75,7 @@
         ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:methods[i]];
         
         // THEN
-        XCTAssertEqual(response.HTTPStatus, 400);
+        XCTAssertEqual(response.HTTPStatus, 404);
         MockUser *user = [self userForEmail:payload[@"email"]];
         XCTAssertNil(user);
     }

--- a/Tests/Source/Users/MockTransportSessionUsersTests.m
+++ b/Tests/Source/Users/MockTransportSessionUsersTests.m
@@ -559,7 +559,7 @@
     ZMTransportResponse *response = [self responseForPayload:@{} path:@"/self/passwprd" method:ZMMethodPUT];
     
     // THEN
-    XCTAssertEqual(response.HTTPStatus, 400);
+    XCTAssertEqual(response.HTTPStatus, 404);
 }
 
 - (void)testThatItDoesNotPutThePasswordIfthePasswordIsAlreadyThereAndTheOldPasswordDoesNotMatch

--- a/Tests/Source/Users/MockTransportSessionUsersTests.swift
+++ b/Tests/Source/Users/MockTransportSessionUsersTests.swift
@@ -47,23 +47,32 @@ final class MockTransportSessionUsersTests_Swift: MockTransportSessionTests {
             secondOtherUserClient = session.registerClient(for: otherUser!, label: "other2", type: "permanent", deviceClass: "phone")
         })
         
-        let redunduntClientId = NSString.createAlphanumerical()
-        var payload: ZMTransportData = [selfUser.identifier: [selfClient.identifier!, redunduntClientId], otherUser.identifier: [otherUserClient.identifier!, secondOtherUserClient.identifier!], thirdUser.identifier: [redunduntClientId]] as ZMTransportData
+        let redunduntClientId = NSString.createAlphanumerical() as String
+        let payload: ZMTransportData = [
+            selfUser.identifier: [selfClient.identifier!, redunduntClientId],
+            otherUser.identifier: [otherUserClient.identifier!, secondOtherUserClient.identifier!],
+            thirdUser.identifier: [redunduntClientId]] as ZMTransportData
         
         let response: ZMTransportResponse = self.response(forPayload: payload, path: "/users/prekeys", method: .methodPOST)
         XCTAssertEqual(response.httpStatus, 200)
         
-        let exepctedUsers: NSArray = [selfUser.identifier, otherUser?.identifier]
+        let expectedUsers: NSArray = [selfUser.identifier, otherUser.identifier, thirdUser.identifier]
         
         let dict = response.payload!.asDictionary()! as NSDictionary
-        assertDictionaryHasKeys(a1: dict, a2: exepctedUsers)
-        
-        var expectedClients = [selfClient?.identifier]
+        assertDictionaryHasKeys(a1: dict, a2: expectedUsers)
+
         if let identifier = selfUser?.identifier {
+            let expectedClients = [selfClient.identifier!, redunduntClientId]
             assertDictionaryHasKeys(a1: response.payload?.asDictionary()?[identifier] as! NSDictionary, a2: expectedClients as NSArray)
         }
-        expectedClients = [otherUserClient?.identifier, secondOtherUserClient?.identifier]
+
         if let identifier = otherUser?.identifier {
+            let expectedClients = [otherUserClient?.identifier, secondOtherUserClient?.identifier]
+            assertDictionaryHasKeys(a1: response.payload?.asDictionary()?[identifier] as! NSDictionary, a2: expectedClients as NSArray)
+        }
+
+        if let identifier = thirdUser?.identifier {
+            let expectedClients = [redunduntClientId]
             assertDictionaryHasKeys(a1: response.payload?.asDictionary()?[identifier] as! NSDictionary, a2: expectedClients as NSArray)
         }
     }


### PR DESCRIPTION
## What's new in this PR?

- Align with BE by returning 404 no-endpoint when a non-existing endpoint is called.
- Align with BE by returning `null` prekeys when requesting a prekey from non-existing client instead of excluding the client completely from the response.