### PR TITLE
[Feature] Add two "/conversations/join" endpoints

### DIFF
--- a/Source/Conversations/MockTransportSession+conversations.m
+++ b/Source/Conversations/MockTransportSession+conversations.m
@@ -45,6 +45,10 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransport";
     {
         return [self processConversationIDsQuery:request.queryParameters];
     }
+    else if ([request matchesWithPath:@"/conversations/join" method:ZMMethodGET])
+    {
+        return [self processFetchConversationIdAndNameWith:request.queryParameters];
+    }
     else if ([request matchesWithPath:@"/conversations/*" method:ZMMethodGET])
     {
         return [self processConversationsGetConversation:[request RESTComponentAtIndex:1]];
@@ -121,6 +125,9 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransport";
     }
     else if ([request matchesWithPath:@"/conversations/*/roles" method:ZMMethodGET]) {
         return [self processFetchRolesForConversation:[request RESTComponentAtIndex:1] payload:[request.payload asDictionary]];
+    }
+    else if ([request matchesWithPath:@"/conversations/join" method:ZMMethodPOST]) {
+        return [self processJoinConversationWithPayload:[request.payload asDictionary]];
     }
 
     return [ZMTransportResponse responseWithPayload:nil HTTPStatus:404 transportSessionError:nil];

--- a/Source/MockTransportSession.m
+++ b/Source/MockTransportSession.m
@@ -626,28 +626,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
     return self.selfUser;
 }
 
-- (MockUser *)insertUserWithName:(NSString *)name;
-{
-    return [self insertUserWithName:name includeClient:YES];
-}
-
-- (MockUser *)insertUserWithName:(NSString *)name includeClient:(BOOL)shouldIncludeClient;
-{
-    MockUser *user = (id) [NSEntityDescription insertNewObjectForEntityForName:@"User" inManagedObjectContext:self.managedObjectContext];
-    user.name = name;
-    user.identifier = [self createUUIDString];
-    user.handle = [self createUUIDString];
-    
-    if (shouldIncludeClient) {
-        
-        MockUserClient *client = [MockUserClient insertClientWithLabel:user.identifier type:@"permanent" deviceClass:@"phone" user:user context:self.managedObjectContext];
-        
-        NSMutableSet *clients = [NSMutableSet setWithObject:client];
-        user.clients = clients;
-    }
-    return user;
-}
-
 - (NSDictionary<NSString *, MockPicture *> *)addProfilePictureToUser:(MockUser *)user
 {
     MockPicture *smallProfile = (id) [NSEntityDescription insertNewObjectForEntityForName:@"Picture" inManagedObjectContext:self.managedObjectContext];

--- a/Source/Users/MockTransportSession+users.swift
+++ b/Source/Users/MockTransportSession+users.swift
@@ -40,4 +40,29 @@ extension MockTransportSession {
         let fields = user.richProfile ?? []
         return ZMTransportResponse(payload: ["fields" : fields ] as ZMTransportData, httpStatus: 200, transportSessionError: nil)
     }
+
+    @objc(insertUserWithName:includeClient:)
+    public func insertUserWith(name: String, includeClient: Bool) -> MockUser {
+        let user = NSEntityDescription.insertNewObject(forEntityName: "User", into: managedObjectContext) as! MockUser
+        user.name = name
+        user.identifier = UUID.create().transportString()
+        user.handle = UUID.create().transportString()
+
+        if includeClient {
+            let client = MockUserClient.insertClient(label: user.identifier,
+                                                     type: "permanent",
+                                                     deviceClass: "phone",
+                                                     for: user,
+                                                     in: managedObjectContext)
+            user.clients = NSMutableSet(array: [client!])
+        }
+
+        return user
+    }
+
+    @objc(insertUserWithName:)
+    public func insertUserWithName(name: String) -> MockUser {
+
+        return self.insertUserWith(name: name, includeClient: true)
+    }
 }

--- a/Tests/Source/Conversations/MockTransportSessionJoinConversationTests.swift
+++ b/Tests/Source/Conversations/MockTransportSessionJoinConversationTests.swift
@@ -1,0 +1,171 @@
+////
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+class MockTransportSessionJoinConversationTests: MockTransportSessionTests {
+
+    var selfUser: MockUser!
+    var conversation: MockConversation!
+
+    override func setUp() {
+        super.setUp()
+        sut.performRemoteChanges { session in
+            self.selfUser = session.insertSelfUser(withName: "me")
+            self.conversation = session.insertConversation(withCreator: self.selfUser, otherUsers: [self.selfUser!], type: .group)
+
+        }
+        XCTAssert(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+    }
+
+    override func tearDown() {
+        selfUser = nil
+        conversation = nil
+        super.tearDown()
+    }
+
+    // MARK: - POST /conversations/join
+
+    func testThatItReturnsCorrectResponse_ForRequestToJoinConversation() {
+        // given
+        let payload = [
+            "code": "test-code",
+            "key": "test-key",
+        ] as ZMTransportData
+
+
+        // when
+        let response = self.response(forPayload: payload, path: "/conversations/join", method: .methodPOST)
+
+        // then
+        XCTAssertEqual(response?.httpStatus, 200)
+        guard let receivedPayload = response?.payload as? [String: Any],
+              let data = receivedPayload["data"] as? [String: Any],
+              let userIds = data["user_ids"] as? [String] else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(receivedPayload["type"] as! String, "conversation.member-join")
+        XCTAssertNotNil(receivedPayload["conversation"])
+        XCTAssertTrue(userIds.contains(selfUser.identifier))
+    }
+
+    func testThatItDoesNotReturnError_WhenConversationExists() {
+        // given
+        let payload = [
+            "code": "existing-conversation-code",
+            "key": "test-key",
+        ] as ZMTransportData
+
+
+        // when
+        let response = self.response(forPayload: payload, path: "/conversations/join", method: .methodPOST)
+
+        // then
+        XCTAssertEqual(response?.httpStatus, 204)
+    }
+
+    func testThatItReturnsError_WhenTheCodeIsInvalid() {
+        // given
+        let payload = [
+            "code": "wrong-code",
+            "key": "test-key",
+        ] as ZMTransportData
+
+
+        // when
+        let response = self.response(forPayload: payload, path: "/conversations/join", method: .methodPOST)
+
+        // then
+        XCTAssertEqual(response?.httpStatus, 404)
+        guard let receivedPayload = response?.payload as? [String: Any] else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(receivedPayload["label"] as! String, "no-conversation-code")
+    }
+
+    // MARK: - GET /conversations/join
+
+    func testThatItReturnsIdAndNameForANewConversation() {
+        // given
+        let path = String(format: "/conversations/join?code=%@&key=%@", "test-code", "test-key")
+
+        // when
+        let response = self.response(forPayload: nil, path: path, method: .methodGET)
+
+        // then
+        XCTAssertEqual(response?.httpStatus, 200)
+        guard let receivedPayload = response?.payload as? [String: Any] else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertNotNil(receivedPayload["id"])
+        XCTAssertNotNil(receivedPayload["name"])
+        let existingConversation = fetchConversation(with: receivedPayload["id"] as! String, in: sut.managedObjectContext)
+        XCTAssertNil(existingConversation)
+    }
+
+    func testThatItReturnsIdAndNameForExistingConversation() {
+        // given
+        let path = String(format: "/conversations/join?code=%@&key=%@", "existing-conversation-code", "test-key")
+
+        // when
+        let response = self.response(forPayload: nil, path: path, method: .methodGET)
+
+        // then
+        XCTAssertEqual(response?.httpStatus, 200)
+        guard let receivedPayload = response?.payload as? [String: Any] else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertNotNil(receivedPayload["id"])
+        XCTAssertNotNil(receivedPayload["name"])
+        let existingConversation = fetchConversation(with: receivedPayload["id"] as! String, in: sut.managedObjectContext)
+        XCTAssertEqual(existingConversation, conversation)
+    }
+
+    func testThatItReturnsError_WhenTheCodeIsInvalid_FetchConversation() {
+        // given
+        let path = String(format: "/conversations/join?code=%@&key=%@", "wrong-code", "test-key")
+
+        // when
+        let response = self.response(forPayload: nil, path: path, method: .methodGET)
+
+        // then
+        XCTAssertEqual(response?.httpStatus, 404)
+        guard let receivedPayload = response?.payload as? [String: Any] else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(receivedPayload["label"] as! String, "no-conversation-code")
+    }
+
+    private func fetchConversation(with identifier: String, in managedObjectContext: NSManagedObjectContext) -> MockConversation? {
+        let request = MockConversation.sortedFetchRequest()
+        request.predicate = NSPredicate(format: "identifier == %@", identifier.lowercased())
+        let conversations = managedObjectContext.executeFetchRequestOrAssert(request) as? [MockConversation]
+        return conversations?.first
+    }
+
+}

--- a/WireMockTransport.xcodeproj/project.pbxproj
+++ b/WireMockTransport.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		06392CFB23C36D30003186E6 /* MockParticipantRole.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06392CFA23C36D30003186E6 /* MockParticipantRole.swift */; };
 		0641A8C4239A56E900B24621 /* MockAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0641A8C3239A56E900B24621 /* MockAction.swift */; };
 		0641A8C6239A581A00B24621 /* MockRole.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0641A8C5239A581A00B24621 /* MockRole.swift */; };
+		06FC1730268053470085B2DF /* MockTransportSessionJoinConversationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FC172F268053470085B2DF /* MockTransportSessionJoinConversationTests.swift */; };
 		09BCDB691BC7CFFC0020DCC7 /* MockTransportSession+OTR.h in Headers */ = {isa = PBXBuildFile; fileRef = 09BCDB671BC7CFFC0020DCC7 /* MockTransportSession+OTR.h */; };
 		09BCDB6A1BC7CFFC0020DCC7 /* MockTransportSession+OTR.m in Sources */ = {isa = PBXBuildFile; fileRef = 09BCDB681BC7CFFC0020DCC7 /* MockTransportSession+OTR.m */; };
 		09E393ED1BB012EA00F3EA1B /* MockTransportSession+Clients.h in Headers */ = {isa = PBXBuildFile; fileRef = 09E393EB1BB012EA00F3EA1B /* MockTransportSession+Clients.h */; };
@@ -158,6 +159,7 @@
 		06392CFA23C36D30003186E6 /* MockParticipantRole.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockParticipantRole.swift; sourceTree = "<group>"; };
 		0641A8C3239A56E900B24621 /* MockAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAction.swift; sourceTree = "<group>"; };
 		0641A8C5239A581A00B24621 /* MockRole.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRole.swift; sourceTree = "<group>"; };
+		06FC172F268053470085B2DF /* MockTransportSessionJoinConversationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTransportSessionJoinConversationTests.swift; sourceTree = "<group>"; };
 		0928E1FA1B975CCE0057232E /* Cartfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
 		0928E1FB1B975CFE0057232E /* Cartfile.private */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile.private; sourceTree = "<group>"; };
 		09BCDB671BC7CFFC0020DCC7 /* MockTransportSession+OTR.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MockTransportSession+OTR.h"; sourceTree = "<group>"; };
@@ -393,6 +395,7 @@
 				F119FC1B2044551200969615 /* MockTransportSessionConversationAccessTests.swift */,
 				F119FC1920444F9C00969615 /* MockTransportSessionConversationsTests.swift */,
 				54AE5A961B78FA62002757E9 /* MockTransportSessionConversationsTests.m */,
+				06FC172F268053470085B2DF /* MockTransportSessionJoinConversationTests.swift */,
 			);
 			path = Conversations;
 			sourceTree = "<group>";
@@ -967,6 +970,7 @@
 				F157FE94206000A700BC25F1 /* MockTransportSessionTeamTests.swift in Sources */,
 				F119FC1A20444F9C00969615 /* MockTransportSessionConversationsTests.swift in Sources */,
 				F157FE9C2060026D00BC25F1 /* MockTransportSessionTeamEventsTests.swift in Sources */,
+				06FC1730268053470085B2DF /* MockTransportSessionJoinConversationTests.swift in Sources */,
 				F157FE83205FFEBC00BC25F1 /* MockTransportPushTokenTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
## What's new in this PR?

This is a feature branch containing 1 approved PR:
wireapp/wire-ios-mocktransport/pull/174

**Changes have been made:**

- new POST /conversations/join endpoint with a mock response
- new GET /conversations/join endpoint with a mock response