### PR TITLE
[Feature] Federation aware connections 

### DIFF
--- a/Source/Connections/MockTransportSession+connections.m
+++ b/Source/Connections/MockTransportSession+connections.m
@@ -159,7 +159,7 @@
 - (ZMTransportResponse *)processPostConnection:(ZMTransportRequest *)sessionRequest
 {
     NSString *userID = [[sessionRequest.payload asDictionary] stringForKey:@"user"];
-    NSString *message = [[sessionRequest.payload asDictionary] stringForKey:@"message"];
+    NSString *message = [[sessionRequest.payload asDictionary] optionalStringForKey:@"message"];
     
     MockUser *user = [self fetchUserWithIdentifier:userID];
     MockConnection *connection = [self createConnectionRequestFromUser:self.selfUser toUser:user message:message];

--- a/Source/Conversations/MockConversation.m
+++ b/Source/Conversations/MockConversation.m
@@ -400,9 +400,9 @@
 {
     NSDictionary *data = @{
                            @"email" : [NSNull null],
-                           @"message" : message,
+                           @"message" : @"",
                            @"name" : user.name,
-                           @"recipiend" : user.identifier
+                           @"recipient" : user.identifier
                            };
     return [self eventIfNeededByUser:byUser type:ZMUpdateEventTypeConversationConnectRequest data:data];
 }


### PR DESCRIPTION
## What's new in this PR?

This is part of a series of PRs which refactor connections and make them federation aware.

- `message` field is no longer required
- Fix typo in payload
