### PR TITLE
chore: Apply asset v3 upload with domain #FS-160

### DIFF
--- a/Source/Assets/MockTransportSession+assets.swift
+++ b/Source/Assets/MockTransportSession+assets.swift
@@ -32,15 +32,13 @@ extension MockTransportSession {
         }
     }
 
-    // V4
-
-    @objc(processAssetV4PostWithDomain:multipart:)
-    public func processAssetV4Post(with domain: String, multipart: [ZMMultipartBodyItem]) -> ZMTransportResponse {
+    @objc(processAssetV3PostWithMultipartData:domain:)
+    public func processAssetV3Post(with multipartData: [ZMMultipartBodyItem], domain: String?) -> ZMTransportResponse {
         guard
-            multipart.count == 2,
-            let jsonObject = multipart.first,
+            multipartData.count == 2,
+            let jsonObject = multipartData.first,
             let json = (try? JSONSerialization.jsonObject(with: jsonObject.data, options: .allowFragments)) as? [String: Any] ,
-            let imageData = multipart.last,
+            let imageData = multipartData.last,
             let mimeType = imageData.contentType
         else {
             return ZMTransportResponse(payload: nil, httpStatus: 400, transportSessionError: nil)
@@ -62,12 +60,14 @@ extension MockTransportSession {
             "token": asset.token
         ].compactMapValues { $0 } as ZMTransportData
 
-        let location = String(format: "/asset/v4/%@", arguments: [asset.identifier])
+        let location = String(format: "/asset/v3/%@", arguments: [asset.identifier])
         return ZMTransportResponse(payload: payload,
                                    httpStatus: 201,
                                    transportSessionError: nil,
                                    headers: ["Location": location])
     }
+
+    // V4
 
     @objc(processAssetV4GetWithDomain:key:)
     public func processAssetV4Get(with domain: String, key: String) -> ZMTransportResponse {

--- a/Tests/Source/Assets/MockTransportSessionAssetsTests.swift
+++ b/Tests/Source/Assets/MockTransportSessionAssetsTests.swift
@@ -119,13 +119,13 @@ class MockTransportSessionAssetsTests : MockTransportSessionTests {
         XCTAssertNil(MockAsset(in: sut.managedObjectContext, forID: asset!.identifier))
     }
 
-    func testUploadingAssetRequestV4() {
+    func testUploadingAssetRequestV3WithDomain() {
         // given
         let data = self.verySmallJPEGData()
 
         // when
         let domain = UUID.create().transportString()
-        let response = self.response(forAssetData: data, contentType: "application/octet-stream", path: "/assets/v4/\(domain)")
+        let response = self.response(forAssetData: data, contentType: "application/octet-stream", path: "/assets/v3/\(domain)")
         XCTAssertNotNil(response)
 
         // then


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-160" title="FS-160" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/secure/viewavatar?size=medium&avatarId=10815&avatarType=issuetype" />FS-160</a>  [iOS] As a user I like to share files in conversations with members from federated backends
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

As the endpoint for uploading the assets in the federated conversations will be v3 with domain instead of v4, removing v4 POST support and adding v3 POST with domain support.
