### PR TITLE
feat: [2FA] Add support for 2FA for login SQSERVICES-1401

### DIFF
--- a/Source/Login/MockTransportSession+login.h
+++ b/Source/Login/MockTransportSession+login.h
@@ -23,5 +23,6 @@
 
 - (ZMTransportResponse *)processLoginRequest:(ZMTransportRequest *)sessionRequest;
 - (ZMTransportResponse *)processLoginCodeRequest:(ZMTransportRequest *)sessionRequest;
+- (ZMTransportResponse *)processVerificationCodeSendRequest:(ZMTransportRequest *)sessionRequest;
 
 @end

--- a/Source/Login/MockTransportSession+login.m
+++ b/Source/Login/MockTransportSession+login.m
@@ -36,11 +36,20 @@ static NSString * const HardcodedAccessToken = @"5hWQOipmcwJvw7BVwikKKN4glSue1Q7
         NSString *email = [request.payload.asDictionary optionalStringForKey:@"email"];
         NSString *phone = [request.payload.asDictionary optionalStringForKey:@"phone"];
         NSString *code = [request.payload.asDictionary optionalStringForKey:@"code"];
-        
+        NSString *verificationCode = [request.payload.asDictionary optionalStringForKey:@"verification_code"];
+
         if((password == nil || email == nil) && (code == nil || phone == nil)) {
             return [self errorResponseWithCode:400 reason:@"missing-key"];
         }
-        
+
+        if(self.emailVerificationCodeForLogin != nil) {
+            if (verificationCode == nil) {
+                return [self errorResponseWithCode:403 reason:@"code-authentication-required"];
+            } else if (![self.emailVerificationCodeForLogin isEqualToString:verificationCode]) {
+                return [self errorResponseWithCode:403 reason:@"code-authentication-failed"];
+            }
+        }
+
         if(phone != nil
            && (
                ! [self.phoneNumbersWaitingForVerificationForLogin containsObject:phone] ||

--- a/Source/MockTransportSession+internal.h
+++ b/Source/MockTransportSession+internal.h
@@ -32,6 +32,7 @@
 - (ZMTransportResponse *)errorResponseWithCode:(NSInteger)code reason:(NSString *)reason;
 - (MockEvent *)eventIfNeededByUser:(MockUser *)byUser type:(ZMUpdateEventType)type data:(id<ZMTransportData>)data;
 
+- (void)generateEmailVerificationCode;
 - (MockConnection *)connectionFromUserIdentifier:(NSString *)fromUserIdentifier toUserIdentifier:(NSString *)toUserIdentifier;
 
 @property (nonatomic, readonly) NSMutableSet *whitelistedEmails;

--- a/Source/MockTransportSession.h
+++ b/Source/MockTransportSession.h
@@ -75,7 +75,7 @@ typedef ZMTransportResponse * _Nullable (^ZMCustomResponseGeneratorBlock)(ZMTran
 
 @property (nonatomic) BOOL useLegaclyPushNotifications;
 
-@property (nonatomic, nullable) NSString *emailVerificationCodeForLogin;
+@property (nonatomic,  readonly, nullable) NSString *generatedEmailVerificationCode;
 
 + (NSString *)binaryDataTypeAsMIME:(NSString *)type;
 

--- a/Source/MockTransportSession.h
+++ b/Source/MockTransportSession.h
@@ -75,6 +75,8 @@ typedef ZMTransportResponse * _Nullable (^ZMCustomResponseGeneratorBlock)(ZMTran
 
 @property (nonatomic) BOOL useLegaclyPushNotifications;
 
+@property (nonatomic, nullable) NSString *emailVerificationCodeForLogin;
+
 + (NSString *)binaryDataTypeAsMIME:(NSString *)type;
 
 - (void)addPushToken:(NSString *)token payload:(NSDictionary *)payload;
@@ -212,6 +214,7 @@ typedef ZMTransportResponse * _Nullable (^ZMCustomResponseGeneratorBlock)(ZMTran
 @property (nonatomic, readonly) NSString *invalidPhoneVerificationCode;
 
 @end
+
 
 NS_ASSUME_NONNULL_END
 

--- a/Source/MockTransportSession.m
+++ b/Source/MockTransportSession.m
@@ -224,6 +224,11 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
     self.shouldKeepPushChannelOpen = NO;
 }
 
+- (void)generateEmailVerificationCode
+{
+    _generatedEmailVerificationCode = @"123456";
+}
+
 - (ZMTransportSession *)mockedTransportSession;
 {
     return (id) self;
@@ -457,7 +462,8 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
              @[@"/invitations", @"processInvitationsRequest:"],
              @[@"/teams", @"processTeamsRequest:"],
              @[@"/broadcast", @"processBroadcastRequest:"],
-             @[@"/providers", @"processServicesProvidersRequest:"]
+             @[@"/providers", @"processServicesProvidersRequest:"],
+             @[@"/verification-code/send", @"processVerificationCodeSendRequest:"]
              ];
 }
 

--- a/Source/MockTransportSession.m
+++ b/Source/MockTransportSession.m
@@ -87,7 +87,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
 /// Completes a request and removes from all pending requests lists
 - (void)completeRequestAndRemoveFromLists:(ZMTransportRequest *)request response:(ZMTransportResponse *)response;
 
-
 @end
 
 
@@ -1118,4 +1117,3 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
 }
 
 @end
-

--- a/Tests/Source/Login/MockTransportSessionLoginTests.m
+++ b/Tests/Source/Login/MockTransportSessionLoginTests.m
@@ -128,8 +128,8 @@
     __block MockUser *selfUser;
     NSString *email = @"doo@example.com";
     NSString *password = @"Bar481516";
-    self.sut.emailVerificationCodeForLogin = @"12345";
-    NSString *verificationCode = self.sut.emailVerificationCodeForLogin;
+    NSString *verificationCode = @"123457";
+    NSString *action = @"login";
 
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
         selfUser = [session insertSelfUserWithName:@"Food"];
@@ -141,20 +141,24 @@
     [[(id) self.sut.cookieStorage reject] setAuthenticationCookieData:OCMOCK_ANY];
 
     // WHEN
-    [self responseForPayload:@{@"email":email} path:@"/login/send" method:ZMMethodPOST];
+    ZMTransportResponse *responseOne = [self responseForPayload:@{@"email":email, @"action":action} path:@"/verification-code/send" method:ZMMethodPOST];
+
+    // THEN
+    XCTAssertNotNil(responseOne);
+    XCTAssertEqual(responseOne.HTTPStatus, 200);
+
 
     // and when
-    ZMTransportResponse *response = [self responseForPayload:@{
+    ZMTransportResponse *responseTwo = [self responseForPayload:@{
                                                                @"email": email,
                                                                @"password": password,
                                                                @"verification_code": verificationCode,
                                                                } path:@"/login" method:ZMMethodPOST];
 
-    // THEN
-    XCTAssertNotNil(response);
-    XCTAssertEqual(response.HTTPStatus, 403);
+    XCTAssertNotNil(responseTwo);
+    XCTAssertEqual(responseTwo.HTTPStatus, 403);
+    XCTAssertEqualObjects([responseTwo payloadLabel], @"code-authentication-failed");
     [self verifyMockLater:self.cookieStorage];
-
 }
 
 - (void)testThatPhoneLoginFailsIfThereIsNoUserWithSuchPhone
@@ -297,8 +301,7 @@
     __block MockUser *selfUser;
     NSString *email = @"doo@example.com";
     NSString *password = @"Bar481516";
-    self.sut.emailVerificationCodeForLogin = @"1245656";
-    NSString *verificationCode = self.sut.emailActivationCode;
+    NSString *verificationCode = @"123457";
 
     [self.sut performRemoteChanges:^(id<MockTransportSessionObjectCreation> session) {
         selfUser = [session insertSelfUserWithName:@"Food"];


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we add support for 2FA (login) in Mock Transport: 

- We mock the interactions that can happen with the new endpoint
- Added more tests regarding the emailVerificationCode to make sure we covered every scenario
- Fixed an issue where we didn't return an error when the `phone` is nil

----

##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`