### PR TITLE
chore: support development api versions FS-709

### DIFF
--- a/Source/API Version/MockTransportSession+APIVersion.swift
+++ b/Source/API Version/MockTransportSession+APIVersion.swift
@@ -35,6 +35,7 @@ extension MockTransportSession {
 
         let payload = [
             "supported": supportedAPIVersions,
+            "development": developmentAPIVersions,
             "domain": domain,
             "federation": federation
         ] as NSDictionary

--- a/Source/MockTransportSession.h
+++ b/Source/MockTransportSession.h
@@ -71,6 +71,8 @@ typedef ZMTransportResponse * _Nullable (^ZMCustomResponseGeneratorBlock)(ZMTran
 
 // What gets returned on GET /api-version
 @property (nonatomic) NSArray<NSNumber *> *supportedAPIVersions;
+@property (nonatomic) NSArray<NSNumber *> *developmentAPIVersions;
+
 @property (nonatomic) NSString *domain;
 @property (nonatomic) BOOL federation;
 @property (nonatomic) BOOL isAPIVersionEndpointAvailable;

--- a/Source/MockTransportSession.m
+++ b/Source/MockTransportSession.m
@@ -135,6 +135,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"MockTransportRequests";
         [MockRole createConversationRolesWithContext:self.managedObjectContext];
 
         self.supportedAPIVersions = [[NSArray alloc] initWithObjects:@0, @1, nil];
+        self.developmentAPIVersions = [[NSArray alloc] init];
         self.domain = @"wire.com";
         self.federation = false;
         self.isAPIVersionEndpointAvailable = true;

--- a/Tests/Source/API Version/MockTransportSessionAPIVersionTests.swift
+++ b/Tests/Source/API Version/MockTransportSessionAPIVersionTests.swift
@@ -24,6 +24,7 @@ class MockTransportSessionAPIVersionTests: MockTransportSessionTests {
         // Given
         let path = "/api-version"
         sut.supportedAPIVersions = [0, 1, 2, 3]
+        sut.developmentAPIVersions = [4]
         sut.domain = "foo.com"
         sut.federation = true
 
@@ -38,6 +39,7 @@ class MockTransportSessionAPIVersionTests: MockTransportSessionTests {
 
         let payload = response?.payload?.asDictionary()
         XCTAssertEqual(payload?["supported"] as? [Int32], sut.supportedAPIVersions.map(\.int32Value))
+        XCTAssertEqual(payload?["development"] as? [Int32], sut.developmentAPIVersions.map(\.int32Value))
         XCTAssertEqual(payload?["domain"] as? String, sut.domain)
         XCTAssertEqual(payload?["federation"] as? Bool, sut.federation)
     }

--- a/Tests/Source/API Version/MockTransportSessionAPIVersionTests.swift
+++ b/Tests/Source/API Version/MockTransportSessionAPIVersionTests.swift
@@ -59,20 +59,18 @@ class MockTransportSessionAPIVersionTests: MockTransportSessionTests {
         XCTAssertEqual(response?.httpStatus, 404)
     }
 
-    // TODO: [John] Uncomment when we add API version 1.
+    func testThatItReturns404IfAPIVersionIsNotZero() {
+        // Given
+        let path = "/api-version"
 
-//    func testThatItReturns404IfAPIVersionIsNotZero() {
-//        // Given
-//        let path = "/api-version"
-//
-//        // Then
-//        let response = self.response(forPayload: [:] as ZMTransportData,
-//                                     path: path,
-//                                     method: .methodGET,
-//                                     apiVersion: .v1)
-//
-//        // Then
-//        XCTAssertEqual(response?.httpStatus, 404)
-//    }
+        // Then
+        let response = self.response(forPayload: [:] as ZMTransportData,
+                                     path: path,
+                                     method: .methodGET,
+                                     apiVersion: .v1)
+
+        // Then
+        XCTAssertEqual(response?.httpStatus, 404)
+    }
 
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-709" title="FS-709" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-709</a>  [iOS] Support API version 2
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Add support for mocking development API versions.

### Testing

#### Test Coverage 

- Updated unit test
- Uncommented a unit test


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
